### PR TITLE
Add doc link on website

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Description
+
+*What did you done in this PR?*
+
+# Tests
+
+1. Steps to reproduce :
+    * ...
+2. Expected results :
+    * ...
+
+# Screenshots
+

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ All these commands are done from the `frontend` directory. Please first move int
 * `npm run start`: start the live compilation in dev mode of the files. Each time you edit a file, the new file is automatically compiled.
 * `npm run build`: build the production compilation of the files. This is useful to check the weight of the files.
 * `npm run build:dev`: compile the files in dev mode (like the start option, except that it doesn't refresh when you edit a file).
+* `npm install --save[-dev] <package_name>`: add a package to the (dev) dependencies

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -127,7 +127,7 @@
               <li><a class="dropdown-item" href="{% url 'account:login' %}"><i class="fas fa-sign-in-alt"></i>&nbsp; Connexion</a></li>
             {% endif %}
             <li>
-              <a class="dropdown-item" href="https://docs.nantral-platform.fr" target="_blank" ref="noopener noreferrer">
+              <a class="dropdown-item" href="https://docs.nantral-platform.fr" target="_blank" rel="noopener noreferrer">
                 <i class="fas fa-question-circle"></i>&nbsp; Documentation
               </a>
             </li>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -113,27 +113,51 @@
           <ul class="dropdown-menu dropdown-menu-end" style="right: 0;" onclick="event.stopPropagation()" aria-labelledby="triggerId">
             {% if request.user.is_authenticated %}
               {% if request.user.student.pk %}
-                <li><a class="dropdown-item" href="{% url 'student:detail' request.user.student.pk %}"><i class="fas fa-user"></i>&nbsp; Mon Profil</a></li>
+                <li>
+                  <a class="dropdown-item" href="{% url 'student:detail' request.user.student.pk %}">
+                    <i class="fas fa-user" aria-hidden="true"></i>&nbsp; Mon Profil
+                  </a>
+                </li>
                 {% if request.user.is_staff %}
-                  <li><a class="dropdown-item" href="{% url 'admin:index' %}"><i class="fas fa-shield-alt"></i>&nbsp; Interface Admin</a></li>
+                  <li>
+                    <a class="dropdown-item" href="{% url 'admin:index' %}">
+                      <i class="fas fa-shield-alt" aria-hidden="true"></i>&nbsp; Interface Admin
+                    </a>
+                  </li>
                 {% endif %}
-                <li><a class="dropdown-item" href="{% url 'account:logout' %}" {# onclick="caches.delete('main-pages');" #}><i class="fas fa-sign-out-alt"></i>&nbsp; Me déconnecter</a></li>
+                <li>
+                  <a class="dropdown-item" href="{% url 'account:logout' %}" {# onclick="caches.delete('main-pages');" #}>
+                    <i class="fas fa-sign-out-alt" aria-hidden="true"></i>&nbsp; Me déconnecter
+                  </a>
+                </li>
               {% else %}
-                <li><a class="dropdown-item disabled" href="">Oooups ! Votre compte est corrompu. Contactez un admin !</a></li>
+                <li>
+                  <a class="dropdown-item disabled" href="">
+                    Oooups ! Votre compte est corrompu. Contactez un admin !
+                  </a>
+                </li>
               {% endif  %}
               <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="{% url 'home:suggestions' %}"><i class="fa fa-exclamation-circle"></i>&nbsp; Suggestion / Bug</a></li>
+              <li>
+                <a class="dropdown-item" href="{% url 'home:suggestions' %}">
+                  <i class="fa fa-exclamation-circle" aria-hidden="true"></i>&nbsp; Suggestion / Bug
+                </a>
+              </li>
             {% else %}
-              <li><a class="dropdown-item" href="{% url 'account:login' %}"><i class="fas fa-sign-in-alt"></i>&nbsp; Connexion</a></li>
+              <li>
+                <a class="dropdown-item" href="{% url 'account:login' %}">
+                  <i class="fas fa-sign-in-alt" aria-hidden="true"></i>&nbsp; Connexion
+                </a>
+              </li>
             {% endif %}
             <li>
               <a class="dropdown-item" href="https://docs.nantral-platform.fr" target="_blank" rel="noopener noreferrer">
-                <i class="fas fa-question-circle"></i>&nbsp; Documentation
+                <i class="fas fa-question-circle" aria-hidden="true"></i>&nbsp; Documentation
               </a>
             </li>
             <li>
               <a class="dropdown-item" href="{% url 'home:mentions' %}">
-                <i class="fas fa-gavel"></i>&nbsp; Mentions Légales
+                <i class="fas fa-gavel" aria-hidden="true"></i>&nbsp; Mentions Légales
               </a>
             </li>
           </ul>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -126,7 +126,16 @@
             {% else %}
               <li><a class="dropdown-item" href="{% url 'account:login' %}"><i class="fas fa-sign-in-alt"></i>&nbsp; Connexion</a></li>
             {% endif %}
-            <li><a class="dropdown-item" href="{% url 'home:mentions' %}"><i class="fas fa-gavel"></i>&nbsp; Mentions Légales</a></li>
+            <li>
+              <a class="dropdown-item" href="https://docs.nantral-platform.fr" target="_blank" ref="noopener noreferrer">
+                <i class="fas fa-question-circle"></i>&nbsp; Documentation
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="{% url 'home:mentions' %}">
+                <i class="fas fa-gavel"></i>&nbsp; Mentions Légales
+              </a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
# Description

* Add a link to the documentation website in the user menu
* Explain how to install a package for the frontend in the readme
* Add a default template for pull requests on github

# Tests

1. Steps to reproduce :
    * Open the user menu on the main website
    * Click the "Documentation" link
2. Expected results :
    * It should open the documentation website

# Screenshots

![image](https://user-images.githubusercontent.com/70099779/199047582-a2f26aad-4f79-4d27-8b5f-d1fae2f840e7.png)
