### PR TITLE
correct signature bug

### DIFF
--- a/backend/apps/tools/templates/tools/signature_gen.html
+++ b/backend/apps/tools/templates/tools/signature_gen.html
@@ -122,7 +122,7 @@
       if ($('input[name="option"]').val() == "") {
         $('#op').text("");
       } else {
-        $('#op').text("<td>Option " + $('input[name="option"]').val() + "</td>");
+        $('#op').text("Option " + $('input[name="option"]').val());
       }
 
       //divers


### PR DESCRIPTION
# Description

* Remove the `<td>` tag on the option

# Tests

1. Steps to reproduce :
    * Generate a signature
2. Expected results :
    * Check that there is no `<td>` tag arround the option

# Screenshots

Avant :
![image](https://user-images.githubusercontent.com/70099779/199058873-fddb2502-c81a-4307-938c-18f8da6bac1a.png)
Après :
![image](https://user-images.githubusercontent.com/70099779/199058799-1cce82db-57b3-4203-8178-0744d8cf1133.png)
