### PR TITLE
correct bug with avataaars

### DIFF
--- a/backend/apps/student/templates/student/student_cards.html
+++ b/backend/apps/student/templates/student/student_cards.html
@@ -23,7 +23,7 @@
                             {% if member.student.picture %}
                                 <img class='icon' src='{{ member.student.picture|file_url }}'>
                             {% else %}
-                                <img class='icon' src="https://avatars.dicebear.com/api/avataaars/{{member.student.name}}.svg" />
+                                <img class='icon' src="https://avatars.dicebear.com/api/avataaars/{{member.student.name}}.svg?style=circle" />
                             {% endif %}
                         </div>
                     </div>

--- a/frontend/src/containers/group/groupMembers/studentCardPicture.tsx
+++ b/frontend/src/containers/group/groupMembers/studentCardPicture.tsx
@@ -10,7 +10,7 @@ export function StudentCardPicture(props: StudentCardBodyProps): JSX.Element {
   const picture =
     member.student.picture !== null
       ? member.student.picture
-      : `https://avatars.dicebear.com/api/avataaars/${member.student.name}}.svg`;
+      : `https://avatars.dicebear.com/api/avataaars/${member.student.name}.svg?style=circle`;
 
   if (editMode) {
     return (


### PR DESCRIPTION
# Description

* Add a circle behind the avataaar for more consistency
* Remove the extra `}` at the end of slugs when calling the image

# Screenshots
![image](https://user-images.githubusercontent.com/70099779/209350073-ea6e385c-25a2-46c2-a2ed-1fbbc91198b4.png)

