### PR TITLE
move context from root to backend

### DIFF
--- a/deployment/containers/web/Dockerfile
+++ b/deployment/containers/web/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /var/app/logs
 RUN mkdir var/app/staticfiles
 WORKDIR  /var/app
 
-COPY backend/Pipfile* /tmp/
+COPY ./Pipfile* /tmp/
 RUN pip install -U pip
 RUN pip install pipenv
 RUN cd /tmp && pipenv requirements > requirements.txt
@@ -31,10 +31,9 @@ RUN pip install -r /tmp/requirements.txt
 
 # Copy stuff in rarest-to-most-often order
 # Files that should basically never change
-COPY backend/manage.py \
-  backend/run_server.sh
+COPY ./manage.py ./run_server.sh ./
 # Files that will change rarely
-COPY backend/templates ./templates
-COPY backend/config ./config
+COPY ./templates ./templates
+COPY ./config ./config
 # Files that will change often
-COPY backend/apps ./apps
+COPY ./apps ./apps

--- a/deployment/containers/web_staging/Dockerfile
+++ b/deployment/containers/web_staging/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /var/app/logs
 RUN mkdir var/app/staticfiles
 WORKDIR  /var/app
 
-COPY backend/Pipfile* /tmp/
+COPY ./Pipfile* /tmp/
 RUN pip install -U pip
 RUN pip install pipenv
 RUN cd /tmp && pipenv requirements > requirements.txt
@@ -31,10 +31,9 @@ RUN pip install -r /tmp/requirements.txt
 
 # Copy stuff in rarest-to-most-often order
 # Files that should basically never change
-COPY backend/manage.py \
-  backend/run_server_staging.sh
+COPY ./manage.py ./run_server_staging.sh ./
 # Files that will change rarely
-COPY backend/templates ./templates
-COPY backend/config ./config
+COPY ./templates ./templates
+COPY ./config ./config
 # Files that will change often
-COPY backend/apps ./apps
+COPY ./apps ./apps

--- a/deployment/docker-compose.override.yml
+++ b/deployment/docker-compose.override.yml
@@ -24,8 +24,8 @@ services:
 
   workers-dashboard:
     build:
-      context: ../
-      dockerfile: deployment/containers/web/Dockerfile
+      context: ../backend/
+      dockerfile: ../deployment/containers/web/Dockerfile
     command: celery -A apps.celery --broker=redis://redis:6379/0 flower --port=5555
     ports:
       - 5555:5555

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -4,8 +4,8 @@ services:
 
   backend-staging:
     build:
-      context: ../../nantralPlatform-staging/
-      dockerfile: ./deployment/containers/web_staging/Dockerfile
+      context: ../../nantralPlatform-staging/backend/
+      dockerfile: ../deployment/containers/web_staging/Dockerfile
     expose:
       - 8001
     command: sh run_server_staging.sh

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -11,8 +11,8 @@ services:
 
   backend:
     build:
-      context: ../
-      dockerfile: deployment/containers/web/Dockerfile
+      context: ../backend/
+      dockerfile: ../deployment/containers/web/Dockerfile
     expose:
       - 8000
     command: sh run_server.sh
@@ -44,8 +44,8 @@ services:
 
   celery:
     build:
-      context: ../
-      dockerfile: deployment/containers/web/Dockerfile
+      context: ../backend/
+      dockerfile: ../deployment/containers/web/Dockerfile
     command: celery -A apps.celery worker -l info
     volumes:
       - ../backend:/var/app
@@ -58,8 +58,8 @@ services:
 
   celery-beat:
     build:
-      context: ../
-      dockerfile: deployment/containers/web/Dockerfile
+      context: ../backend/
+      dockerfile: ../deployment/containers/web/Dockerfile
     command: celery -A apps.celery beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     volumes:
       - ../backend:/var/app


### PR DESCRIPTION
# Description

Change the `context` for building containers from the `root` directory to the `backend` directory.
This should avoid docker trying to read files (for examples ones from `mail` services) that it doesn't need to read.

# Tests

It runs on my machine 🙃


