### PR TITLE
fix: celery errors

### DIFF
--- a/backend/apps/notification/tasks.py
+++ b/backend/apps/notification/tasks.py
@@ -37,7 +37,7 @@ def clean_notifications():
     """A simple celery task to delete the old notifications"""
 
     # we decide to delete all notifications older than 60 days
-    timeperiod = datetime.timedelta(day=60)
+    timeperiod = datetime.timedelta(days=60)
     # then get the day of today
     today = timezone.now()
     # import the Notification model


### PR DESCRIPTION
# Description

Fix errors that would prevent celery tasks from running.


Associated log
```
[2023-01-17 22:36:44,488: ERROR/ForkPoolWorker-1] Task apps.notification.tasks.clean_notifications[8ad8ea55-7938-4b36-8f9b-06eef4e9f0a9] raised unexpected: TypeError("'day' is an invalid keyword argument for __new__()")
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/app/apps/notification/tasks.py", line 40, in clean_notifications
    timeperiod = datetime.timedelta(day=60)
TypeError: 'day' is an invalid keyword argument for __new__()
```

