### PR TITLE
React app event filter function

### DIFF
--- a/frontend/src/components/Accordion/SimpleAccordion.scss
+++ b/frontend/src/components/Accordion/SimpleAccordion.scss
@@ -1,3 +1,5 @@
 .accordion{
   background-color: inherit;
+  padding: 3px 4px 3px 1px;
+  width: inherit;
 }

--- a/frontend/src/components/Accordion/SimpleAccordion.tsx
+++ b/frontend/src/components/Accordion/SimpleAccordion.tsx
@@ -11,21 +11,21 @@ function SimpleAccordion(props: { label: string; icon: any; content: any }) {
   const { label, icon, content } = props;
 
   return (
-    <div>
-      <Accordion square className="accordion">
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1a-content"
-          id="panel1a-header"
-        >
-          <ListItemIcon>{icon}</ListItemIcon>
-          <Typography component="span">{label}</Typography>
-        </AccordionSummary>
-        <AccordionDetails>
-          <Typography component="span">{content}</Typography>
-        </AccordionDetails>
-      </Accordion>
-    </div>
+    // <div>
+    <Accordion square className="accordion">
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel1a-content"
+        id="panel1a-header"
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <Typography component="span">{label}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography component="span">{content}</Typography>
+      </AccordionDetails>
+    </Accordion>
+    // </div>
   );
 }
 

--- a/frontend/src/components/Checkbox/CheckboxesTags/CheckboxesTags.tsx
+++ b/frontend/src/components/Checkbox/CheckboxesTags/CheckboxesTags.tsx
@@ -43,7 +43,7 @@ function CheckboxesTags(props: { label: string; getResult: any }) {
           {option.title}
         </li>
       )}
-      style={{ width: 230 }}
+      // style={{ width: 230 }}
       onChange={handleChange}
       renderInput={(params) => (
         <TextField {...params} label={label} multiline placeholder={label} />

--- a/frontend/src/components/DatePicker/BasicDatePicker.tsx
+++ b/frontend/src/components/DatePicker/BasicDatePicker.tsx
@@ -7,7 +7,7 @@ import 'dayjs/locale/fr';
 import TextField from '@mui/material/TextField';
 
 // TO DO : UN BOUTON POUR ENLEVER LA DATE CHOISIE
-
+// TO DO : make adapterLocale and toolbarTitle adapt to the language selected
 export default function BasicDatePicker(props: {
   label: string;
   minDate: any;

--- a/frontend/src/components/DatePicker/BasicDatePicker.tsx
+++ b/frontend/src/components/DatePicker/BasicDatePicker.tsx
@@ -22,12 +22,17 @@ export default function BasicDatePicker(props: {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="fr">
+    <LocalizationProvider
+      dateAdapter={AdapterDayjs}
+      adapterLocale="fr"
+      style={{ width: 230 }}
+    >
       <DatePicker
         minDate={minDate}
         label={label}
         value={valueDebut}
         onChange={handleChange}
+        toolbarTitle="dd/mm/yyyy"
         renderInput={(params) => <TextField {...params} />}
       />
     </LocalizationProvider>

--- a/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/FilterBar/FilterBar.tsx
@@ -99,7 +99,11 @@ function FilterBar(props: { getFilter: any }) {
       name: 'Organisateur',
       icon: <GroupsIcon />,
       isMenu: true,
-      content: <CheckboxesTags label="Organisateur" getResult={getOrganiser} />,
+      content: (
+        <Grid item xs="auto">
+          <CheckboxesTags label="Organisateur" getResult={getOrganiser} />
+        </Grid>
+      ),
     },
     {
       id: 'date',
@@ -126,6 +130,13 @@ function FilterBar(props: { getFilter: any }) {
           </Grid>
         </>
       ),
+    },
+    {
+      id: 'test',
+      name: 'Test',
+      icon: <DateRangeIcon />,
+      isMenu: true,
+      content: 'test',
     },
   ];
 

--- a/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/FilterBar/FilterBar.tsx
@@ -14,6 +14,7 @@ import './FilterBar.scss';
 import IconButton from '@mui/material/IconButton';
 import { Grid } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
+import { Dayjs } from 'dayjs';
 import SimpleAccordion from '../Accordion/SimpleAccordion';
 import CheckboxesTags from '../Checkbox/CheckboxesTags/CheckboxesTags';
 import CheckboxButton from '../Checkbox/CheckboxButton/CheckboxButton';
@@ -30,9 +31,8 @@ interface FilterInterface {
 function FilterBar(props: { getFilter: any }) {
   const { getFilter } = props;
   const [open, setOpen] = React.useState(false);
-  const [dateBegin, setDateBegin] = React.useState(null);
-  const [dateBeginTransformed, setDateBeginTransformed] = React.useState(null);
-  const [dateEndTransformed, setDateEndTransformed] = React.useState(null);
+  const [dateBegin, setDateBegin] = React.useState<Dayjs | null>(null);
+  const [dateEnd, setDateEnd] = React.useState(null);
   const [isFavorite, setIsFavorite] = React.useState(false);
   const [isParticipated, setIsParticipated] = React.useState(false);
   const [isShotgun, setIsShotgun] = React.useState(false);
@@ -41,14 +41,9 @@ function FilterBar(props: { getFilter: any }) {
 
   const getDateBegin = (newDate) => {
     setDateBegin(newDate);
-    if (newDate !== null) {
-      setDateBeginTransformed(newDate.format('DD/MM/YYYY'));
-    }
   };
   const getDateEnd = (newDate) => {
-    if (newDate !== null) {
-      setDateEndTransformed(newDate.format('DD/MM/YYYY'));
-    }
+    setDateEnd(newDate);
   };
   const getChecked = (id, checked) => {
     if (id === 'favorite') {
@@ -65,8 +60,8 @@ function FilterBar(props: { getFilter: any }) {
     setOrganiser(organiserDic);
   };
 
-  currentFilter.set('dateBegin', dateBeginTransformed);
-  currentFilter.set('dateEnd', dateEndTransformed);
+  currentFilter.set('dateBegin', dateBegin);
+  currentFilter.set('dateEnd', dateEnd);
   currentFilter.set('favorite', isFavorite);
   currentFilter.set('participate', isParticipated);
   currentFilter.set('shotgun', isShotgun);
@@ -130,13 +125,6 @@ function FilterBar(props: { getFilter: any }) {
           </Grid>
         </>
       ),
-    },
-    {
-      id: 'test',
-      name: 'Test',
-      icon: <DateRangeIcon />,
-      isMenu: true,
-      content: 'test',
     },
   ];
 

--- a/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/FilterBar/FilterBar.tsx
@@ -27,11 +27,6 @@ interface FilterInterface {
   content: any;
 }
 
-interface ResultInterface {
-  id: string;
-  value: any;
-}
-
 function FilterBar(props: { getFilter: any }) {
   const { getFilter } = props;
   const [open, setOpen] = React.useState(false);
@@ -42,6 +37,7 @@ function FilterBar(props: { getFilter: any }) {
   const [isParticipated, setIsParticipated] = React.useState(false);
   const [isShotgun, setIsShotgun] = React.useState(false);
   const [organiser, setOrganiser] = React.useState(null);
+  const currentFilter = new Map();
 
   const getDateBegin = (newDate) => {
     setDateBegin(newDate);
@@ -68,16 +64,43 @@ function FilterBar(props: { getFilter: any }) {
   const getOrganiser = (organiserDic) => {
     setOrganiser(organiserDic);
   };
-  const currentFilter: ResultInterface[] = [
-    { id: 'dateBegin', value: { dateBeginTransformed } },
-    { id: 'dateEnd', value: { dateEndTransformed } },
-    { id: 'favorite', value: { isFavorite } },
-    { id: 'participate', value: { isParticipated } },
-    { id: 'organiser', value: { organiser } },
-    { id: 'shotgun', value: { isShotgun } },
-  ];
+
+  currentFilter.set('dateBegin', dateBeginTransformed);
+  currentFilter.set('dateEnd', dateEndTransformed);
+  currentFilter.set('favorite', isFavorite);
+  currentFilter.set('participate', isParticipated);
+  currentFilter.set('shotgun', isShotgun);
+  currentFilter.set('organiser', organiser);
 
   const filters: FilterInterface[] = [
+    {
+      id: 'favorite',
+      name: 'Favoris',
+      icon: <FavoriteIcon />,
+      isMenu: false,
+      content: null,
+    },
+    {
+      id: 'participate',
+      name: 'Je participe',
+      icon: <PersonIcon />,
+      isMenu: false,
+      content: null,
+    },
+    {
+      id: 'shotgun',
+      name: 'Shotgun',
+      icon: <TimerIcon />,
+      isMenu: false,
+      content: null,
+    },
+    {
+      id: 'organiser',
+      name: 'Organisateur',
+      icon: <GroupsIcon />,
+      isMenu: true,
+      content: <CheckboxesTags label="Organisateur" getResult={getOrganiser} />,
+    },
     {
       id: 'date',
       name: 'Date',
@@ -103,34 +126,6 @@ function FilterBar(props: { getFilter: any }) {
           </Grid>
         </>
       ),
-    },
-    {
-      id: 'favorite',
-      name: 'Favoris',
-      icon: <FavoriteIcon />,
-      isMenu: false,
-      content: null,
-    },
-    {
-      id: 'participate',
-      name: 'Je participe',
-      icon: <PersonIcon />,
-      isMenu: false,
-      content: null,
-    },
-    {
-      id: 'organiser',
-      name: 'Organisateur',
-      icon: <GroupsIcon />,
-      isMenu: true,
-      content: <CheckboxesTags label="Organisateur" getResult={getOrganiser} />,
-    },
-    {
-      id: 'shotgun',
-      name: 'Shotgun',
-      icon: <TimerIcon />,
-      isMenu: false,
-      content: null,
     },
   ];
 

--- a/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/FilterBar/FilterBar.tsx
@@ -32,10 +32,9 @@ interface ResultInterface {
   value: any;
 }
 
-function FilterBar() {
-  const [state, setState] = React.useState({
-    right: false,
-  });
+function FilterBar(props: { getFilter: any }) {
+  const { getFilter } = props;
+  const [open, setOpen] = React.useState(false);
   const [dateBegin, setDateBegin] = React.useState(null);
   const [dateBeginTransformed, setDateBeginTransformed] = React.useState(null);
   const [dateEndTransformed, setDateEndTransformed] = React.useState(null);
@@ -43,7 +42,6 @@ function FilterBar() {
   const [isParticipated, setIsParticipated] = React.useState(false);
   const [isShotgun, setIsShotgun] = React.useState(false);
   const [organiser, setOrganiser] = React.useState(null);
-  const [validateFilter, setValidateFilter] = React.useState(null);
 
   const getDateBegin = (newDate) => {
     setDateBegin(newDate);
@@ -57,10 +55,10 @@ function FilterBar() {
     }
   };
   const getChecked = (id, checked) => {
-    if (id === 'favoris') {
+    if (id === 'favorite') {
       setIsFavorite(checked);
     }
-    if (id === 'participe') {
+    if (id === 'participate') {
       setIsParticipated(checked);
     }
     if (id === 'shotgun') {
@@ -70,6 +68,14 @@ function FilterBar() {
   const getOrganiser = (organiserDic) => {
     setOrganiser(organiserDic);
   };
+  const currentFilter: ResultInterface[] = [
+    { id: 'dateBegin', value: { dateBeginTransformed } },
+    { id: 'dateEnd', value: { dateEndTransformed } },
+    { id: 'favorite', value: { isFavorite } },
+    { id: 'participate', value: { isParticipated } },
+    { id: 'organiser', value: { organiser } },
+    { id: 'shotgun', value: { isShotgun } },
+  ];
 
   const filters: FilterInterface[] = [
     {
@@ -128,33 +134,19 @@ function FilterBar() {
     },
   ];
 
-  const currentFilter: ResultInterface[] = [
-    { id: 'dateBegin', value: { dateBeginTransformed } },
-    { id: 'dateEnd', value: { dateEndTransformed } },
-    { id: 'favorite', value: { isFavorite } },
-    { id: 'participate', value: { isParticipated } },
-    { id: 'organiser', value: { organiser } },
-    { id: 'shotgun', value: { isShotgun } },
-  ];
+  const validate = () => {
+    setOpen(false);
+    getFilter(currentFilter);
+  };
 
-  const toggleDrawer =
-    (anchor: 'right', open: boolean) =>
-    (event: React.KeyboardEvent | React.MouseEvent) => {
-      if (
-        event.type === 'keydown' &&
-        ((event as React.KeyboardEvent).key === 'Tab' ||
-          (event as React.KeyboardEvent).key === 'Shift')
-      ) {
-        return;
-      }
-
-      setState({ ...state, [anchor]: open });
-    };
-
-  const list = (anchor: 'right') => (
+  const list = () => (
     <Box className="center" role="presentation">
       <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-        <IconButton onClick={toggleDrawer(anchor, false)}>
+        <IconButton
+          onClick={() => {
+            setOpen(false);
+          }}
+        >
           <Close />
         </IconButton>
       </div>
@@ -184,7 +176,7 @@ function FilterBar() {
       </List>
       <div style={{ height: '15px' }}></div>
       <div>
-        <Button onClick={toggleDrawer(anchor, false)} variant="contained">
+        <Button onClick={validate} variant="contained">
           Valider
         </Button>
       </div>
@@ -197,7 +189,9 @@ function FilterBar() {
           <Button
             style={{ textTransform: 'none', padding: '2px 8px' }}
             variant="contained"
-            onClick={toggleDrawer(anchor, true)}
+            onClick={() => {
+              setOpen(true);
+            }}
             endIcon={<FilterAltIcon />}
           >
             Filtrer
@@ -205,8 +199,10 @@ function FilterBar() {
           <Drawer
             keepMounted
             anchor={anchor}
-            open={state[anchor]}
-            onClose={toggleDrawer(anchor, false)}
+            open={open}
+            onClose={() => {
+              setOpen(false);
+            }}
             sx={{
               width: 300,
               flexShrink: 0,
@@ -216,7 +212,7 @@ function FilterBar() {
               },
             }}
           >
-            {list(anchor)}
+            {list()}
           </Drawer>
         </React.Fragment>
       ))}

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -22,7 +22,7 @@ import Formular from '../../components/Formular/Formular'
  */
 function EventList(props: { events: any }) {
   const { events } = props;
-  console.log(events);
+  // console.log(events);
 
   return <p>Ceci est une liste.</p>;
 }
@@ -66,6 +66,11 @@ function EventView(props: { events: any }) {
 
 function Event() {
   const [events, setEvents] = React.useState<Array<EventProps>>([]);
+  const [filter, setFilter] = React.useState(null);
+
+  const getFilter = (validateFilter) => {
+    setFilter(validateFilter);
+  }
 
   React.useEffect(() => {
     axios.get('/api/event').then((res: any) => {
@@ -92,7 +97,7 @@ function Event() {
       <p>Ceci est la page des events</p>
       <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
         <Formular />
-        <FilterBar />
+        <FilterBar getFilter={getFilter}/>
       </div> 
       <EventView events={events} />
     </>

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -21,6 +21,7 @@ import Formular from '../../components/Formular/Formular'
 /**
  * Function used to filter a single event depending on the state of the filterbar
  * @returns event if it matches the filter, null if not
+ * @TODO move this function to backend
  */
 const filterFunction=(event:EventProps, filter: Map<string, any>) => {
 
@@ -55,6 +56,7 @@ const filterFunction=(event:EventProps, filter: Map<string, any>) => {
  * @param events all events from the database
  * @param filter filter chosen by the user in the filterbar
  * @returns events filtered if there is a filter, all events if not
+ * @todo move this function to backend
  */
 const filterEvent=(events: Array<EventProps>, filter: Map<string, any>) => {
   if (filter !== undefined){

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -20,6 +20,55 @@ import Formular from '../../components/Formular/Formular'
  * Event Page, with Welcome message, next events, etc...
  * @returns Event page component
  */
+
+
+const filterFunction=(event:EventProps, filter: Map<string, any>) => {
+  // //logique d'union pour tous les filtres sauf date. Si le filtre est vide, affichage de tous les events.
+  // const keepUnion = [];
+  // if (filter.get('dateBegin')=== null && filter.get('dateEnd')=== null 
+  // && filter.get('shotgun')=== false  && filter.get('participate')===false 
+  // && filter.get('favorite')===false && filter.get('organiser')!==null){  
+  //   return event;
+  // }
+  // if(filter.get('favorite')===true && event.isFavorite===true){
+  //   keepUnion.push(true);
+  // } else {
+  //   keepUnion.push(false);
+  // }
+  // if(filter.get('participate')===true && event.isParticipating===true){
+  //   keepUnion.push(true);
+  // } else {
+  //   keepUnion.push(false);
+  // }
+  // if (keepUnion.includes(true)){
+  // return event} 
+  // return null;
+
+  // logique exclusive partout
+  if(filter.get('favorite')===true && event.isFavorite!==true){
+    return null;
+  }
+  
+  if(filter.get('participate')===true && event.isParticipating!==true){
+    return null;
+  }
+
+  if(filter.get('shotgun')===true && event.maxParticipant===null){
+    return null;
+  }
+ 
+  return event;
+  
+}
+
+const filterEvent=(events: Array<EventProps>, filter: Map<string, any>) => {
+  if (events !== undefined && filter !== undefined){
+    return(events.filter((event) => filterFunction(event, filter)))
+  }
+
+  return events;
+}
+
 function EventList(props: { events: any }) {
   const { events } = props;
   // console.log(events);
@@ -66,11 +115,12 @@ function EventView(props: { events: any }) {
 
 function Event() {
   const [events, setEvents] = React.useState<Array<EventProps>>([]);
-  const [filter, setFilter] = React.useState(null);
+  const [filter, setFilter] = React.useState<Map<string,any>>();
 
   const getFilter = (validateFilter) => {
     setFilter(validateFilter);
   }
+ console.log(filterEvent(events, filter));
 
   React.useEffect(() => {
     axios.get('/api/event').then((res: any) => {
@@ -99,7 +149,7 @@ function Event() {
         <Formular />
         <FilterBar getFilter={getFilter}/>
       </div> 
-      <EventView events={events} />
+      <EventView events={events}/>
     </>
   );
 }

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -16,47 +16,30 @@ import FilterBar from '../../components/FilterBar/FilterBar';
 import Calendar from '../../components/Calendar/Calendar';
 import Formular from '../../components/Formular/Formular'
 
+
+
 /**
- * Event Page, with Welcome message, next events, etc...
- * @returns Event page component
+ * Function used to filter a single event depending on the state of the filterbar
+ * @returns event if it matches the filter, null if not
  */
-
-
 const filterFunction=(event:EventProps, filter: Map<string, any>) => {
-  // //logique d'union pour Organiser. si le filtre est vide, affichage de tous les events.
-  // const keepUnion = [];
-  // if (filter.get('dateBegin')=== null && filter.get('dateEnd')=== null 
-  // && filter.get('shotgun')=== false  && filter.get('participate')===false 
-  // && filter.get('favorite')===false && filter.get('organiser')!==null){  
-  //   return event;
-  // }
-  // if(filter.get('favorite')===true && event.isFavorite===true){
-  //   keepUnion.push(true);
-  // } else {
-  //   keepUnion.push(false);
-  // }
-  // if(filter.get('participate')===true && event.isParticipating===true){
-  //   keepUnion.push(true);
-  // } else {
-  //   keepUnion.push(false);
-  // }
-  // if (keepUnion.includes(true)){
-  // return event} 
-  // return null;
 
-  // logique exclusive partout
+  // filter for favorite events
   if(filter.get('favorite')===true && event.isFavorite!==true){
     return null;
   }
   
+  // filter for participated events
   if(filter.get('participate')===true && event.isParticipating!==true){
     return null;
   }
 
+  // filter for shotgun events
   if(filter.get('shotgun')===true && event.maxParticipant===null){
     return null;
   }
 
+  // filter for date
   if(filter.get('dateBegin')!==null && filter.get('dateEnd')===null){
     if (filter.get('dateBegin').isAfter(event.endDate)){
       return null;
@@ -73,14 +56,20 @@ const filterFunction=(event:EventProps, filter: Map<string, any>) => {
     if (filter.get('dateBegin').isAfter(event.endDate) || filter.get('dateEnd').isBefore(event.beginDate)){
       return null;
     }
-
   }
 
+  // filter for organiser
  
   return event;
   
 }
 
+/**
+ * Function used to filter all the events
+ * @param events all events from the database
+ * @param filter filter chosen by the user in the filterbar
+ * @returns events filtered if there is a filter, all events if not
+ */
 const filterEvent=(events: Array<EventProps>, filter: Map<string, any>) => {
   if (filter !== undefined){
     return(events.filter((event) => filterFunction(event, filter)))
@@ -133,6 +122,10 @@ function EventView(props: { events: any }) {
   );
 }
 
+/**
+ * Event Page, with Welcome message, next events, etc...
+ * @returns Event page component
+ */
 function Event() {
   const [events, setEvents] = React.useState<Array<EventProps>>([]);
   const [filter, setFilter] = React.useState<Map<string,any>>();

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -24,7 +24,7 @@ import Formular from '../../components/Formular/Formular'
  */
 const filterFunction=(event:EventProps, filter: Map<string, any>) => {
 
-  // filter for favorite events
+  // filter for checkboxes
   if((filter.get('favorite')===true && event.isFavorite!==true)||
   (filter.get('participate')===true && event.isParticipating!==true)||
   (filter.get('shotgun')===true && event.maxParticipant===null)){
@@ -32,20 +32,14 @@ const filterFunction=(event:EventProps, filter: Map<string, any>) => {
   }
 
   // filter for date
-  if(filter.get('dateBegin')!==null && filter.get('dateEnd')===null){
+  if(filter.get('dateBegin')!==null){
     if (filter.get('dateBegin').isAfter(event.endDate)){
       return null;
     }
   }
 
-  if(filter.get('dateBegin')===null && filter.get('dateEnd')!==null){
+  if(filter.get('dateEnd')!==null){
     if (filter.get('dateEnd').isBefore(event.beginDate)){
-      return null;
-    }
-  }
-
-  if(filter.get('dateBegin')!==null && filter.get('dateEnd')!==null){
-    if (filter.get('dateBegin').isAfter(event.endDate) || filter.get('dateEnd').isBefore(event.beginDate)){
       return null;
     }
   }

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -23,7 +23,7 @@ import Formular from '../../components/Formular/Formular'
 
 
 const filterFunction=(event:EventProps, filter: Map<string, any>) => {
-  // //logique d'union pour tous les filtres sauf date. Si le filtre est vide, affichage de tous les events.
+  // //logique d'union pour Organiser. si le filtre est vide, affichage de tous les events.
   // const keepUnion = [];
   // if (filter.get('dateBegin')=== null && filter.get('dateEnd')=== null 
   // && filter.get('shotgun')=== false  && filter.get('participate')===false 
@@ -56,13 +56,33 @@ const filterFunction=(event:EventProps, filter: Map<string, any>) => {
   if(filter.get('shotgun')===true && event.maxParticipant===null){
     return null;
   }
+
+  if(filter.get('dateBegin')!==null && filter.get('dateEnd')===null){
+    if (filter.get('dateBegin').isAfter(event.endDate)){
+      return null;
+    }
+  }
+
+  if(filter.get('dateBegin')===null && filter.get('dateEnd')!==null){
+    if (filter.get('dateEnd').isBefore(event.beginDate)){
+      return null;
+    }
+  }
+
+  if(filter.get('dateBegin')!==null && filter.get('dateEnd')!==null){
+    if (filter.get('dateBegin').isAfter(event.endDate) || filter.get('dateEnd').isBefore(event.beginDate)){
+      return null;
+    }
+
+  }
+
  
   return event;
   
 }
 
 const filterEvent=(events: Array<EventProps>, filter: Map<string, any>) => {
-  if (events !== undefined && filter !== undefined){
+  if (filter !== undefined){
     return(events.filter((event) => filterFunction(event, filter)))
   }
 

--- a/frontend/src/pages/Event/Event.tsx
+++ b/frontend/src/pages/Event/Event.tsx
@@ -25,17 +25,9 @@ import Formular from '../../components/Formular/Formular'
 const filterFunction=(event:EventProps, filter: Map<string, any>) => {
 
   // filter for favorite events
-  if(filter.get('favorite')===true && event.isFavorite!==true){
-    return null;
-  }
-  
-  // filter for participated events
-  if(filter.get('participate')===true && event.isParticipating!==true){
-    return null;
-  }
-
-  // filter for shotgun events
-  if(filter.get('shotgun')===true && event.maxParticipant===null){
+  if((filter.get('favorite')===true && event.isFavorite!==true)||
+  (filter.get('participate')===true && event.isParticipating!==true)||
+  (filter.get('shotgun')===true && event.maxParticipant===null)){
     return null;
   }
 
@@ -80,7 +72,7 @@ const filterEvent=(events: Array<EventProps>, filter: Map<string, any>) => {
 
 function EventList(props: { events: any }) {
   const { events } = props;
-  // console.log(events);
+  console.log(events);
 
   return <p>Ceci est une liste.</p>;
 }


### PR DESCRIPTION
# Description

- Get all filters from Filterbar into Event page
- Create filter function that filters events according to the filter (for shotgun, je participe, favoris and date)
- Fix some width problems in the filterbar
- Changing the order of the filters in the filterbar

# Tests

Go on the Event Page and click on the 'filtrer' button : 
- the 3 checkboxes are at the top of the two accordion filters
- on mobile phone and on computer : the width of the checkboxes and accordions adapt to the width of the drawer
- In the console, you can see an array that contains the events to display. When you choose a value in a filter (except for organisateur), and click on 'valider', the array is filtered and only contains the events that match the filter.

# Screenshots
![image](https://user-images.githubusercontent.com/112811926/220325022-14e477c8-e8fd-46cd-b506-475980300f72.png)
![image](https://user-images.githubusercontent.com/112811926/220325096-d3223e9b-04ec-4f6c-9aa2-9c8c473e7890.png)
![image](https://user-images.githubusercontent.com/112811926/220325786-6f35bf2d-5d28-4296-8ecd-b65f72b99e0f.png)
![image](https://user-images.githubusercontent.com/112811926/220326068-599a1c46-debe-4924-8ec6-0cd7dfae7d81.png)

