### PR TITLE
Update Group APIs

### DIFF
--- a/backend/apps/group/serializers.py
+++ b/backend/apps/group/serializers.py
@@ -43,8 +43,8 @@ class SimpleGroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Group
-        fields = ['name', 'slug', 'url', 'icon']
-        read_only_fields = ['name', 'slug', 'url', 'icon']
+        fields = ['name', 'short_name', 'slug', 'url', 'icon']
+        read_only_fields = ['name', 'short_name', 'slug', 'url', 'icon']
 
     def get_url(self, obj: Group) -> str:
         return obj.get_absolute_url()

--- a/backend/apps/group/templates/group/detail.html
+++ b/backend/apps/group/templates/group/detail.html
@@ -201,7 +201,7 @@
             const groupSlug = "{{ group.slug }}";
             const displayType = 'grid';
         </script>
-        <script src='{% static "js/group/MembershipsGroup.js" %}?v=1'></script>
+        <script src='{% static "js/group/MembershipsGroup.js" %}?v=1.1'></script>
     {% endif %}
 
     {# Bouton pour faire une demande pour devenir admin #}

--- a/backend/apps/group/tests.py
+++ b/backend/apps/group/tests.py
@@ -32,29 +32,26 @@ class TestGroups(APITestCase):
 
     def test_list(self):
         self.client.force_login(self.u1)
-        # test without indicating a group type
-        res = self.client.get('/api/group/group/')
-        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         # test an empty list
         res = self.client.get('/api/group/group/', {'type': 't1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 0)
+        self.assertEqual(len(res.data.get('results')), 0)
         # test with a group
         g = Group.objects.create(name="G1", group_type=self.t1)
         res = self.client.get('/api/group/group/', {'type': 't1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 1)
+        self.assertEqual(len(res.data.get('results')), 1)
         # test with a private group
         g.private = True
         g.save()
         res = self.client.get('/api/group/group/', {'type': 't1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 0)
+        self.assertEqual(len(res.data.get('results')), 0)
         # test with a private group where the user is member
         g.members.add(self.u1.student)
         res = self.client.get('/api/group/group/', {'type': 't1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 1)
+        self.assertEqual(len(res.data.get('results')), 1)
 
     def test_create(self):
         self.client.force_login(self.u1)
@@ -158,35 +155,32 @@ class TestMemberships(APITestCase):
 
     def test_list(self):
         self.client.force_login(self.u1)
-        # test without indicating a group or a student
-        res = self.client.get('/api/group/membership/')
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
         # test an empty list
         res = self.client.get('/api/group/membership/', {'group': 'g1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 0)
+        self.assertEqual(len(res.data.get('results')), 0)
         # test with one membership
         self.g1.members.add(self.u2.student)
         res = self.client.get('/api/group/membership/', {'group': 'g1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 1)
+        self.assertEqual(len(res.data.get('results')), 1)
         # test with a private group
         self.g1.private = True
         self.g1.save()
         res = self.client.get('/api/group/membership/', {'group': 'g1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 0)
+        self.assertEqual(len(res.data.get('results')), 0)
         # test with a private group where the user is member
         self.g1.members.add(self.u1.student)
         res = self.client.get('/api/group/membership/', {'group': 'g1'})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 2)
+        self.assertEqual(len(res.data.get('results')), 2)
         self.g1.private = False
         self.g1.save()
         # test on student
         res = self.client.get('/api/group/membership/', {'student': self.u2.id})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 1)
+        self.assertEqual(len(res.data.get('results')), 1)
         # test if non authenticated
         self.client.logout()
         res = self.client.get('/api/group/membership/', {'group': 'g1'})

--- a/backend/apps/student/templates/student/profile.html
+++ b/backend/apps/student/templates/student/profile.html
@@ -53,5 +53,5 @@
 <script>
     const studentId = "{{ object.id }}";
 </script>
-<script src='{% static "js/group/MembershipsStudent.js" %}'></script>
+<script src='{% static "js/group/MembershipsStudent.js" %}?v=1'></script>
 {% endblock %}

--- a/backend/apps/utils/searchAPIMixin.py
+++ b/backend/apps/utils/searchAPIMixin.py
@@ -14,9 +14,18 @@ class SearchAPIMixin:
     @action(detail=False, methods=['get'])
     def search(self, request: Request, *args, **kwargs):
         """
-        A view to search through elements of the table. You must provides
-        'search_fields' (a list of fields in which to search).
+        A view to search through elements of the table, filtered by the
+        'search_fields' property.
 
+        Query Paramers
+        --------------
+        q: str
+            The text string to search
+        limit: bool
+            The max number of objects to query (by default 5)
+
+        Sources
+        -------
         Based on the django-admin contrib package (see
         https://docs.djangoproject.com/en/4.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_search_results
         and

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -199,6 +199,12 @@ STAGING = env('STAGING')
 ### THIRD PARTY LIBRARIES SETTINGS ###
 ######################################
 
+# Rest API settings
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 50
+}
+SILENCED_SYSTEM_CHECKS = ["rest_framework.W001"]
+
 # Extra Settings
 EXTRA_SETTINGS_CACHE_NAME = "extra_settings"
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2450,6 +2450,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7421,6 +7422,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9802,6 +9804,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13376,6 +13379,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/frontend/src/containers/group/MembershipsGroup.tsx
+++ b/frontend/src/containers/group/MembershipsGroup.tsx
@@ -4,11 +4,16 @@ import {
   Snackbar,
   Alert,
   Button,
-  Box
+  Box,
+  IconButton,
 } from '@mui/material';
-import { Edit as EditIcon } from '@mui/icons-material';
+import {
+  Edit as EditIcon,
+  NavigateBefore as NavigateBeforeIcon,
+  NavigateNext as NavigateNextIcon
+} from '@mui/icons-material';
 import ModalEditMember from './components/ModalEditMember';
-import { Group, Membership, Student } from './interfaces';
+import { Group, Membership, Student, Page } from './interfaces';
 import axios from '../utils/axios';
 import ListMembershipsGrid from './components/ListMembershipsGrid';
 import ListMembershipsTable from './components/ListMembershipsTable';
@@ -16,6 +21,14 @@ import ListMembershipsTable from './components/ListMembershipsTable';
 // passed through django template
 declare const groupSlug: string;
 declare const displayType: 'grid' | 'table';
+
+interface QueryParams {
+  group: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
 
 /**
  * Main table component for editing members in the admin page of groups.
@@ -29,8 +42,10 @@ function MembershipsGroup(props: {}): JSX.Element {
   // status of modals
   const [ message, setMessage ] = useState<{type: any; text: string }>({ type: null, text: '' });
   const [ openAddModal, setOpenAddModal ] = useState(false);
-  // filters passed as query parameters
-  const [ filters, setFilters ] = useState<{group: string; from?: string; to?: string}>({
+  // urls and filters passed as query parameters
+  const [ prevUrl, setPrevUrl ] = useState('');
+  const [ nextUrl, setNextUrl ] = useState('');
+  const [ filters, setFilters ] = useState<QueryParams>({
     group: groupSlug,
     from: new Date().toISOString()
   });
@@ -52,13 +67,22 @@ function MembershipsGroup(props: {}): JSX.Element {
   }, []);
 
   /** Get the list of members */
-  async function getMemberships(): Promise<void> {
-    return axios.get<Membership[]>('/api/group/membership/', {params: filters})
-    .then((res) => res.data.map((item) => {
-      item.dragId = `item-${item.id}`;  // add a dragId for the drag-and-drop
-      return item;
-    }))
-    .then((list) => setMembers(list));
+  async function getMemberships(
+    url='/api/group/membership/',
+    query_params: Partial<QueryParams>=filters
+  ): Promise<void> {
+    return axios.get<Page<Membership>>(url, {params: query_params})
+    .then((res) => res.data)
+    .then((data) => {
+        setMembers(
+          data.results.map((item) => {
+            item.dragId = `item-${item.id}`;  // add a dragId for the drag-and-drop
+            return item;
+          })
+        );
+        setPrevUrl(data.previous);
+        setNextUrl(data.next);
+    });
   }
 
   /**
@@ -163,13 +187,14 @@ function MembershipsGroup(props: {}): JSX.Element {
         />
       }
       <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
-        { group.is_admin && displayType === 'grid'
-        ? <Button
-            variant='contained'
-            href='edit/members'
-            endIcon={<EditIcon />}
-          >Modifier</Button>
-        : <></> }
+        <Button
+          variant='contained'
+          hidden={ !group.is_admin || displayType !== 'grid' }
+          href='edit/members'
+          endIcon={<EditIcon />}
+        >
+          Modifier
+        </Button>
         { !group.is_member && !group.lock_memberships || group.is_admin
         ? <>
             <Button
@@ -192,7 +217,7 @@ function MembershipsGroup(props: {}): JSX.Element {
         ? <Button
             variant='text'
             onClick={() => {
-              filters.from = undefined;
+              setFilters({ ...filters, from: undefined });
               getMemberships();
             }}
           >
@@ -201,13 +226,19 @@ function MembershipsGroup(props: {}): JSX.Element {
         : <Button
             variant='text'
             onClick={() => {
-              filters.from = new Date().toISOString();
+              setFilters({ ...filters, from: new Date().toISOString() });
               getMemberships();
             }}
           >
             Masquer les anciens membres
           </Button>
         }
+        <IconButton sx={{ml: 'auto'}} disabled={!prevUrl} onClick={() => getMemberships(prevUrl, {})}>
+          <NavigateBeforeIcon />
+        </IconButton>
+        <IconButton disabled={!nextUrl} onClick={() => getMemberships(nextUrl, {})}>
+          <NavigateNextIcon />
+        </IconButton>
       </Box>
       <Snackbar
         autoHideDuration={4000}

--- a/frontend/src/containers/group/components/ModalEditMember.tsx
+++ b/frontend/src/containers/group/components/ModalEditMember.tsx
@@ -80,7 +80,8 @@ function createBlankMember(group: Group, student: Student): Membership {
     begin_date: today,
     end_date: oneYearLater,
     admin: false,
-    priority: 0
+    priority: 0,
+    dragId: ''
   };
   return member;
 }

--- a/frontend/src/containers/group/interfaces.ts
+++ b/frontend/src/containers/group/interfaces.ts
@@ -1,20 +1,21 @@
-export interface Group {
-  id: number;
+
+export interface SimpleGroup {
   name: string;
   short_name: string;
+  slug: string;
+  url: string;
+  icon?: string;
+}
+
+export interface Group extends SimpleGroup {
+  id: number;
   group_type: {
     name: string;
     slug: string;
     no_membership_dates: boolean;
   };
-  parent: {
-    name: string;
-    slug: string;
-    url: string;
-    icon: string;
-  };
-  creation_year: number;
-  slug: string;
+  parent?: SimpleGroup;
+  creation_year?: number;
   archived: boolean;
   private: boolean;
   public: boolean;
@@ -22,14 +23,19 @@ export interface Group {
   description: string;
   meeting_place: string;
   meeting_hour: string;
-  icon: string;
   banner: string;
   video1: string;
   video2: string;
-  url: string;
   is_admin: boolean;
   is_member: boolean;
   lock_memberships: boolean;
+}
+
+export interface SimpleStudent {
+  id: number;
+  full_name: string;
+  url: string;
+  picture: string;
 }
 
 export interface Student {
@@ -63,4 +69,11 @@ export interface Membership {
   admin: boolean;
   admin_request?: boolean;
   dragId: string;
+}
+
+export interface Page<T> {
+  count: number;
+  next: string;
+  previous: string;
+  results: T[];
 }


### PR DESCRIPTION
# Description

Add a paginator for groups and memberships apis. It limits the number of items downloaded by 50 by default, and give an url to download the next (or previous) 50 ones.
Add also a `simple` query paramters for group, allowing to only fetch the minimum possible data instead of every details of each item.
Remove the constraint to give a type for group api.
Remove the constraint to give a group or a student for membership api.

## Breaking change

In the front end, the `res.data` object returned from axios is now an object of type `{ count: number; previous: string; next: string; results: T[] }`, where `results` is the list of requested objects, instead of just the list of objects. 
Note that it only affects `list` actions (i.e. the `GET /api/<app>/<table>/` endpoint), and not all the other actions (create, retrieve, update, delete, search...). See screenshot below.

# Tests

Tests updated. You can try to use [http://localhost:8000/api/group/group/](http://localhost:8000/api/group/group/) and [http://localhost:8000/api/group/membership/](http://localhost:8000/api/group/membership/).

# Screenshots

![image](https://user-images.githubusercontent.com/70099779/222256371-717d7f72-ec40-46c2-8560-7a9d61210f4e.png)

