### PR TITLE
React app crumbs

### DIFF
--- a/frontend/src/components/NavBarTop/NavBarTop.tsx
+++ b/frontend/src/components/NavBarTop/NavBarTop.tsx
@@ -106,6 +106,7 @@ function NavBarTop(props: {
   const { t } = useTranslation('translation');
 
   const breadcrumbNameMap: { [key: string]: string } = {
+    '/home/': t('navbar.home'),
     '/event/': t('navbar.events'),
     '/club/': t('navbar.clubs'),
     '/colocs/': t('navbar.flatshare'),
@@ -119,7 +120,7 @@ function NavBarTop(props: {
     '/legal_mentions/': 'Legal',
   };
   const location = useLocation();
-  const pathnames = location.pathname.split('/').filter((x) => x);
+  const pathnames = ('/home' + location.pathname).split('/').filter((x) => x);
 
   return (
     <AppBar position="fixed" color="secondary">
@@ -141,30 +142,20 @@ function NavBarTop(props: {
         />
         <Box sx={{ flexGrow: 0.02 }} />
         <Breadcrumbs
-          sx={{ display: { xs: 'none', md: 'flex' } }}
           aria-label="breadcrumb"
+          sx={{ display: { xs: 'none', md: 'flex' } }}
         >
           <Typography
             variant="h6"
             component="div"
             color="textPrimary"
-            sx={{ display: { xs: 'none', md: 'flex' } }}
           >
             Nantral Platform
           </Typography>
-          <LinkMui
-            component={Link}
-            to="/"
-            color="textPrimary"
-            underline="hover"
-            variant="h6"
-          >
-            {t('navbar.home')}
-          </LinkMui>
           {pathnames.map((value, index) => {
             const last = index === pathnames.length - 1;
-            const to = `/${pathnames.slice(0, index + 1)}/`;
-
+            const to = (index == 0) ? '/home/' : `/${pathnames.slice(1, index + 1)}/`;
+            
             return last ? (
               <Typography key={to}>{breadcrumbNameMap[to]}</Typography>
             ) : (
@@ -172,7 +163,7 @@ function NavBarTop(props: {
                 component={Link}
                 underline="hover"
                 color="textPrimary"
-                to={to}
+                to = {(to === '/home/') ? '/' : to}
                 key={to}
                 variant="h6"
               >


### PR DESCRIPTION
# Description

Le 1er lien ("accueil" pour la page d'accueil) n'est un lien que si ce n'est pas le dernier lien, contrairement à avant.
Les breadcrumbs disparaissent en version mobile, car sinon seuls les "/" apparaissent, moyen stylé.

# Tests

Aller sur la page d'accueil : "accueil" apparait, mais n'est pas cliquable.
Aller sur une autre page : "accueil" cliquable apparait, ainsi que le nom (non-cliquable) de la page courante.
Cliquer sur "accueil" : on revient sur la page d'accueil.

# Screenshots

![image](https://user-images.githubusercontent.com/95407459/224279763-d32c3a9e-93fa-445c-a341-6262ca4bdfe7.png)
(sur la page "accueil")

![image](https://user-images.githubusercontent.com/95407459/224280194-51550405-1bb8-4555-a128-096ac2848afc.png)
(sur la page "évènement")

![image](https://user-images.githubusercontent.com/95407459/224279854-da48ca57-7f62-4359-be61-cdc3265da59a.png)
(sur mobile)