### PR TITLE
fix auto resize in chooseWeek component

### DIFF
--- a/frontend/src/components/Calendar/ChooseWeek/ChangeWeek/ChangeWeek.tsx
+++ b/frontend/src/components/Calendar/ChooseWeek/ChangeWeek/ChangeWeek.tsx
@@ -89,10 +89,11 @@ export function ChangeWeek(props: {
         }}
         style={{
           minWidth: `1px`,
+          padding: '0px',
         }}
         data-testid="ChangeWeekPreviousTestId"
       >
-        {/* <ArrowBackIosNewIcon></ArrowBackIosNewIcon> */}
+        <ArrowBackIosNewIcon style={{ width: 'inherit' }}></ArrowBackIosNewIcon>
       </Button>
     );
   }
@@ -122,10 +123,11 @@ export function ChangeWeek(props: {
       }}
       style={{
         minWidth: `1px`,
+        padding: '0px',
       }}
       data-testid="ChangeWeekNextTestId"
     >
-      {/* <ArrowForwardIosIcon></ArrowForwardIosIcon> */}
+      <ArrowForwardIosIcon style={{ width: 'inherit' }}></ArrowForwardIosIcon>
     </Button>
   );
 }

--- a/frontend/src/components/Calendar/ChooseWeek/ChooseWeek.tsx
+++ b/frontend/src/components/Calendar/ChooseWeek/ChooseWeek.tsx
@@ -50,7 +50,7 @@ export function ChooseWeek(props: {
         })}
       </div>
       <div id="changeAreaOfTime">
-        <Grid container justifyContent="center" xs={12}>
+        <Grid container justifyContent="center">
           <Grid item xs={1}>
             <ChangeWeek
               action="previous"

--- a/frontend/src/components/Calendar/ChooseWeek/DateBox/DateBox.tsx
+++ b/frontend/src/components/Calendar/ChooseWeek/DateBox/DateBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CalendarMonth } from '@mui/icons-material';
-import { Button, Container, Grid } from '@mui/material';
+import { Button } from '@mui/material';
 
 /**
  * The DateBox component which displays the current week and allow to change by click.
@@ -9,6 +9,7 @@ import { Button, Container, Grid } from '@mui/material';
  */
 export function DateBox(props: { date: Date; endDate: Date }): JSX.Element {
   const { date, endDate } = props;
+  // @todo implement the change date with the CalendarMonth button
   const sunday = new Date(
     endDate.getFullYear(),
     endDate.getMonth(),
@@ -26,13 +27,10 @@ export function DateBox(props: { date: Date; endDate: Date }): JSX.Element {
         data-testid="DateBoxTestId"
         style={{
           minWidth: `1px`,
+          padding: '0px',
         }}
       >
-        <Grid container justifyContent="center" xs={12}>
-          <Grid item xs={12}>
-            <CalendarMonth></CalendarMonth>
-          </Grid>
-        </Grid>
+        <CalendarMonth style={{ width: 'inherit' }}></CalendarMonth>
       </Button>
     </div>
   );

--- a/frontend/src/components/Calendar/Day/Day.tsx
+++ b/frontend/src/components/Calendar/Day/Day.tsx
@@ -110,7 +110,7 @@ export function Day(props: {
 
   return (
     <div id={day} style={{ display: 'block' }}>
-      {day}
+      {day[0]}
       {dayChain}
       {chains.map((chain, number) => (
         <Grid


### PR DESCRIPTION
# Description

Fix resize of ChooseWeek component

# Tests

1. Steps to reproduce :

Go to calendar in the event page and test multiple size of screen

2. Expected results :

It adapts itself

# Screenshots

![image](https://user-images.githubusercontent.com/97662746/224329920-5c167a80-531a-4dfa-81e9-ab6cc57a0670.png)
![image](https://user-images.githubusercontent.com/97662746/224329871-1363c0c7-8673-4691-b7f1-1c847336fe23.png)
