### PR TITLE
fix: nginx upstream resolution fail

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -20,6 +20,11 @@ services:
       - STAGING=True
 
   nginx:
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "https://nantral-platform.fr"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot/:ro


### PR DESCRIPTION
If Nginx starts before the prod Django container is up and listening for requests, Nginx will fail all requests redirected to the (not yet available) upstream.

This fix checks that nantral-platform.fr is accessible every 30s and restarts the Nginx container if needed.

Most importantly, this will allow us to reboot our VPS without having to manually restart Nginx (this caused the website to be down on the 11th of May 2023