### PR TITLE
Bug parrainage

### DIFF
--- a/backend/apps/family/forms.py
+++ b/backend/apps/family/forms.py
@@ -104,7 +104,7 @@ class FamilyQuestionItiiForm(FamilyQuestionsForm):
 
 class MemberQuestionsForm(forms.Form):
 
-    def __init__(self, page, is_2A_plus, initial, *args, **kwargs):  # noqa:N803
+    def __init__(self, page, is_2Aplus, initial, *args, **kwargs):  # noqa:N803
         super(MemberQuestionsForm, self).__init__(
             initial=initial, *args, **kwargs)
         self.use_required_attribute = False
@@ -113,7 +113,7 @@ class MemberQuestionsForm(forms.Form):
         for question in questions:
             try:
                 show_question = (
-                    not is_2A_plus or question.equivalent.quota < 100)
+                    not is_2Aplus or question.equivalent.quota < 100)
             except Exception:
                 show_question = True
             if show_question:

--- a/backend/apps/family/forms.py
+++ b/backend/apps/family/forms.py
@@ -20,7 +20,7 @@ class UpdateFamilyForm(forms.ModelForm):
     """Modifier une famille existante"""
     class Meta:
         model = Family
-        fields = ['name', 'summary', 'non_subscribed_members']
+        fields = ['name', 'summary',]
 
 
 class MemberForDeleteForm(forms.BaseInlineFormSet):

--- a/backend/apps/family/views.py
+++ b/backend/apps/family/views.py
@@ -253,13 +253,6 @@ class UpdateFamilyView(UserIsAdmin, TemplateView):
             FamilyQuestionsForm(data=request.POST)
         ]
         if forms[0].is_valid() and forms[1].is_valid() and forms[2].is_valid():
-            # on vérifie le nb de membres
-            # non_subscribed_list = forms[0].cleaned_data[
-            #     'non_subscribed_members']
-            # if non_subscribed_list:
-            #     nb_non_subscribed = len((non_subscribed_list).split(','))
-            # else:
-            #     nb_non_subscribed = 0
             nb_non_subscribed = 0
             nb_subscribed = 0
             for form in forms[1]:

--- a/backend/apps/family/views.py
+++ b/backend/apps/family/views.py
@@ -254,12 +254,13 @@ class UpdateFamilyView(UserIsAdmin, TemplateView):
         ]
         if forms[0].is_valid() and forms[1].is_valid() and forms[2].is_valid():
             # on vérifie le nb de membres
-            non_subscribed_list = forms[0].cleaned_data[
-                'non_subscribed_members']
-            if non_subscribed_list:
-                nb_non_subscribed = len((non_subscribed_list).split(','))
-            else:
-                nb_non_subscribed = 0
+            # non_subscribed_list = forms[0].cleaned_data[
+            #     'non_subscribed_members']
+            # if non_subscribed_list:
+            #     nb_non_subscribed = len((non_subscribed_list).split(','))
+            # else:
+            #     nb_non_subscribed = 0
+            nb_non_subscribed = 0
             nb_subscribed = 0
             for form in forms[1]:
                 if hasattr(form.instance, 'student'):


### PR DESCRIPTION
# Description

Fixed a typo is_2Aplus and removed the option to add non subscribed members during the family creation to prevent exploits.

# Tests

1. Steps to reproduce :
    - Create a new family as a EI2
2. Expected results :
    - No option to add non subscribed members appears
