### PR TITLE
Change export in makefile for powershell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq '$(findstring ;,$(PATH))' ';'
 	PYTHON := python
 	COPY := copy
 	PIPENV := $(PYTHON) -m pipenv
-	EXPORT = set $(1) $(2)
+	EXPORT = set $(1)=$(2)
 endif
 
 


### PR DESCRIPTION
# Description

Change the equivalent of the bash export in makefile for windows to ensure a correct setup of the PIPENV_VENV_IN_PROJECT variable

# Tests

1. Steps to reproduce :
    Run make install after cloning the repo in powershell or in cmd on windows.
2. Expected results :
    The command will work, whereas before it quitted with an error saying "PIPENV_VENV_IN_PROJECT  1 is not defined

# Screenshots
![image](https://github.com/3cn-ecn/nantralPlatform/assets/114158809/cd1bb413-dba6-4f31-b281-e9a14aafe774)
Old behavior

![image](https://github.com/3cn-ecn/nantralPlatform/assets/114158809/f649fc02-4366-4f5e-b395-be052dfa932e)
Correct execution of the script after the change


