### PR TITLE
fix: remove force-renew

### DIFF
--- a/deployment/docker-compose.override.yml
+++ b/deployment/docker-compose.override.yml
@@ -3,24 +3,24 @@ version: "2.1"
 services:
   database:
     ports:
-      - '5432:5432'
+      - "5432:5432"
     env_file: ../backend/config/settings/.env
-  
+
   backend:
     env_file: ../backend/config/settings/.env
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.docker
 
   # External dependencies
-  
+
   nginx:
     build: ./containers/nginx_local
-  
+
   celery:
     env_file: ../backend/config/settings/.env
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.docker
-  
+
   celery-beat:
     env_file: ../backend/config/settings/.env
     environment:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1,7 +1,6 @@
 version: "2.1"
 
 services:
-
   backend-staging:
     build:
       context: ../../nantralPlatform-staging/backend/

--- a/deployment/scripts/certbot-renew.sh
+++ b/deployment/scripts/certbot-renew.sh
@@ -21,7 +21,7 @@
 cd /home/ubuntu/nantralPlatform/deployment
 
 # Renew certificates
-certbot certonly --cert-name nantral-platform.fr --force-renew --webroot --webroot-path ./certbot/www/ -d nantral-platform.fr -d webmail.nantral-platform.fr -d dev.nantral-platform.fr -d www.nantral-platform.fr -d mail.nantral-platform.fr
+certbot certonly --cert-name nantral-platform.fr --expand --webroot --webroot-path ./certbot/www/ -d nantral-platform.fr -d webmail.nantral-platform.fr -d dev.nantral-platform.fr -d www.nantral-platform.fr -d mail.nantral-platform.fr
 
 # Move certificates to handle mails
 cp /etc/letsencrypt/live/nantral-platform.fr/privkey.pem /home/ubuntu/nantralPlatform/deployment/certs/key.pem || exit 1


### PR DESCRIPTION
# Description

Prevent certbot to create a new certificate when a domain is added to or removed from the list.

## ⚠️ **DO NOT MERGE THIS MERGE REQUEST BEFORE 31 AUGUST !!!!**⚠️

TO-DO: `git reset --hard`  on the server to remove custom edits (but only when we can generate again certificates)
