### PR TITLE
fix: clean email to lowercase when upgrading from temporary account

### DIFF
--- a/backend/apps/account/admin.py
+++ b/backend/apps/account/admin.py
@@ -10,6 +10,47 @@ from django.utils.translation import gettext_lazy as _
 from .models import IdRegistration, TemporaryAccessRequest
 
 
+class UppercaseEmailFilter(admin.SimpleListFilter):
+    title = "mail avec majuscules"
+    parameter_name = "uppercase_email"
+
+    def lookups(self, request, model_admin):
+        return (("has_uppercase", "A des majuscules"),)
+
+    def queryset(self, request, queryset):
+        if self.value() == "has_uppercase":
+            return queryset.filter(email__regex=r"[A-Z]")
+
+
+class ECNantesDomainFilter(admin.SimpleListFilter):
+    title = _("mail Centrale Nantes")
+    parameter_name = "ecnantes_domain"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("with_domain", "ec-nantes.fr"),
+            ("without_domain", "autres hébergeurs"),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "with_domain":
+            return queryset.filter(email__regex=r"@(\w+\.)?ec-nantes\.fr$")
+        if self.value() == "without_domain":
+            return queryset.exclude(email__regex=r"@(\w+\.)?ec-nantes\.fr$")
+
+
+class NoPasswordFilter(admin.SimpleListFilter):
+    title = "mot de passe vide"
+    parameter_name = "no_password"
+
+    def lookups(self, request, model_admin):
+        return (("no_password", "Mot de passe vide"),)
+
+    def queryset(self, request, queryset):
+        if self.value() == "no_password":
+            return queryset.filter(password="")  # noqa: S106
+
+
 @admin.register(IdRegistration)
 class IdRegistrationAdmin(admin.ModelAdmin):
     list_display = ["id"]
@@ -75,4 +116,13 @@ class CustomUserAdmin(UserAdmin):
                 "fields": ("email", "password1", "password2"),
             },
         ),
+    )
+    list_filter = (
+        "is_staff",
+        "is_superuser",
+        "is_active",
+        "groups",
+        UppercaseEmailFilter,
+        ECNantesDomainFilter,
+        NoPasswordFilter,
     )

--- a/backend/apps/account/forms.py
+++ b/backend/apps/account/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from apps.student.models import FACULTIES, PATHS
 
@@ -15,8 +16,8 @@ from .models import IdRegistration
 User = get_user_model()
 
 
-def check_id(id):
-    if not IdRegistration.objects.filter(id=id).exists():
+def check_id(id_to_check: str):
+    if not IdRegistration.objects.filter(id=id_to_check).exists():
         raise ValidationError(
             _(
                 "Invitation invalide : le lien d'invitation a expiré. Veuillez "
@@ -52,41 +53,49 @@ def check_passwords(pass1, pass2):
 
 class SignUpForm(UserCreationForm):
     email = forms.EmailField(
+        label=gettext_lazy("Adresse mail"),
         max_length=200,
         validators=[check_ecn_mail],
         required=True,
-        help_text=_("Votre adresse mail ec-nantes.fr"),
+        help_text=gettext_lazy("Votre adresse mail ec-nantes.fr"),
     )
     confirm_email = forms.EmailField(
-        max_length=200, required=True, help_text=_("Confirmez votre adresse.")
+        label=gettext_lazy("Confirmation de l'adresse mail"),
+        max_length=200,
+        required=True,
+        help_text=gettext_lazy("Confirmez votre adresse."),
     )
-    promo = forms.IntegerField(min_value=1919, required=True)
-    first_name = forms.CharField(max_length=200, required=True)
-    last_name = forms.CharField(max_length=200, required=True)
-    faculty = forms.ChoiceField(required=True, choices=FACULTIES)
+    promo = forms.IntegerField(
+        label=gettext_lazy("Année d'arrivée à Centrale"),
+        min_value=1919,
+        required=True,
+    )
+    first_name = forms.CharField(
+        label=gettext_lazy("Prénom"), max_length=200, required=True
+    )
+    last_name = forms.CharField(
+        label=gettext_lazy("Nom"), max_length=200, required=True
+    )
+    faculty = forms.ChoiceField(
+        label=gettext_lazy("Filière"), required=True, choices=FACULTIES
+    )
     path = forms.ChoiceField(
+        label=gettext_lazy("Cursus particulier ?"),
         choices=PATHS,
-        help_text=_("Vous pourrez modifier cela plus tard"),
+        help_text=gettext_lazy("Vous pourrez modifier cela plus tard"),
         required=False,
     )
 
     def __init__(self, *args, **kwargs):
-        super(SignUpForm, self).__init__(*args, **kwargs)
-        self.fields["email"].label = _("Adresse mail")
-        self.fields["confirm_email"].label = _("Confirmation de l'adresse mail")
-        self.fields["first_name"].label = _("Prénom")
-        self.fields["last_name"].label = _("NOM")
+        super().__init__(*args, **kwargs)
         self.fields["password1"].label = _("Mot de passe")
         self.fields["password2"].label = _("Confirmation du mot de passe")
         self.fields["password2"].help_text = _(
             "Entrez le même mot de passe pour vérification"
         )
-        self.fields["promo"].label = _("Année d'arrivée à Centrale")
-        self.fields["faculty"].label = _("Filière")
-        self.fields["path"].label = _("Cursus particulier ?")
 
     def clean(self):
-        cleaned_data = super(SignUpForm, self).clean()
+        cleaned_data = super().clean()
         email = cleaned_data.get("email")
         confirm_email = cleaned_data.get("confirm_email")
         try:
@@ -119,12 +128,12 @@ class LoginForm(forms.Form):
         max_length=200,
         validators=[check_ecn_mail_login],
         required=True,
-        help_text=_("Votre adresse mail ec-nantes.fr"),
+        help_text=gettext_lazy("Votre adresse mail ec-nantes.fr"),
     )
     password = forms.CharField(widget=forms.PasswordInput)
 
     def __init__(self, *args, **kwargs):
-        super(LoginForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["password"].label = _("Mot de passe")
         self.fields["password"].help_text = (
             f"<a class='text-muted' href='/account/forgotten'>"
@@ -153,12 +162,12 @@ class ResetPassForm(forms.Form):
     password_confirm = forms.CharField(widget=forms.PasswordInput)
 
     def __init__(self, *args, **kwargs):
-        super(ResetPassForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["password"].label = _("Votre nouveau mot de passe")
         self.fields["password_confirm"].label = _("Confirmer le mot de passe")
 
     def clean(self):
-        cleaned_data = super(ResetPassForm, self).clean()
+        cleaned_data = super().clean()
         password = cleaned_data.get("password")
         password_confirm = cleaned_data.get("password_confirm ")
 
@@ -178,7 +187,7 @@ class TemporaryRequestSignUpForm(SignUpForm):
     email = forms.EmailField(
         max_length=200,
         required=True,
-        help_text=_("Votre adresse mail personnelle."),
+        help_text=gettext_lazy("Votre adresse mail personnelle."),
     )
     invite_id = forms.UUIDField(
         validators=[check_id], widget=forms.HiddenInput()
@@ -191,6 +200,6 @@ class UpgradePermanentAccountForm(forms.Form):
     email = forms.EmailField(
         max_length=200,
         required=True,
-        help_text=_("Votre adresse mail Centrale Nantes."),
+        help_text=gettext_lazy("Votre adresse mail Centrale Nantes."),
         validators=[check_ecn_mail],
     )

--- a/backend/apps/account/forms.py
+++ b/backend/apps/account/forms.py
@@ -202,3 +202,7 @@ class UpgradePermanentAccountForm(forms.Form):
         help_text=_("Votre adresse mail Centrale Nantes."),
         validators=[check_ecn_mail],
     )
+
+    def clean_email(self) -> str:
+        data: str = self.cleaned_data["email"]
+        return data.lower()

--- a/backend/apps/account/forms.py
+++ b/backend/apps/account/forms.py
@@ -100,14 +100,6 @@ class SignUpForm(UserCreationForm):
                     )
             return cleaned_data
 
-    def clean_email(self) -> str:
-        data: str = self.cleaned_data["email"]
-        return data.lower()
-
-    def clean_confirm_email(self) -> str:
-        data: str = self.cleaned_data["confirm_email"]
-        return data.lower()
-
     class Meta:
         model = User
         fields = (
@@ -202,7 +194,3 @@ class UpgradePermanentAccountForm(forms.Form):
         help_text=_("Votre adresse mail Centrale Nantes."),
         validators=[check_ecn_mail],
     )
-
-    def clean_email(self) -> str:
-        data: str = self.cleaned_data["email"]
-        return data.lower()

--- a/backend/apps/account/locale/en/LC_MESSAGES/django.po
+++ b/backend/apps/account/locale/en/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-17 14:27+0200\n"
-"PO-Revision-Date: 2023-04-10 15:37+0200\n"
+"POT-Creation-Date: 2023-10-20 20:07+0200\n"
+"PO-Revision-Date: 2023-10-20 20:08+0200\n"
 "Last-Translator: Alexis Delage <alexidelage@gmail.com>\n"
 "Language-Team: \n"
 "Language: en\n"
@@ -16,121 +16,119 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.4\n"
 
-#: admin.py:52
+#: admin.py:53
 msgid "Info personnelles"
 msgstr "Personal info"
 
-#: admin.py:54
+#: admin.py:57
 msgid "Permissions"
 msgstr "Permissions"
 
-#: admin.py:65
+#: admin.py:68
 msgid "Dates Importantes"
 msgstr "Important dates"
 
-#: forms.py:22
+#: forms.py:23
 msgid ""
-"Invitation invalide : le lien d'invitation a expiré. Veuillez entrer une "
+"Invitation invalide : le lien d'invitation a expiré. Veuillez entrer une "
 "adresse en ec-nantes.fr, ou contactez un administrateur."
 msgstr ""
 "Invalid invitation: the invitation link has expired. Please enter an email "
 "finishing by ec-nantes.fr, or contact an administrator."
 
-#: forms.py:33
+#: forms.py:34
 msgid ""
 "Vous devez utiliser une adresse mail de Centrale Nantes finissant par ec-"
 "nantes.fr"
 msgstr "You have to use your school email ending in ec-nantes.fr"
 
-#: forms.py:50 forms.py:176
+#: forms.py:51 forms.py:177
 msgid "Les deux mots de passe ne correspondent pas."
 msgstr "The passwords don't match."
 
-#: forms.py:58 forms.py:130
+#: forms.py:56
+msgid "Adresse mail"
+msgstr "Email"
+
+#: forms.py:60 forms.py:131
 msgid "Votre adresse mail ec-nantes.fr"
 msgstr "Your school email in ec-nantes.fr"
 
-#: forms.py:61
+#: forms.py:63
+msgid "Confirmation de l'adresse mail"
+msgstr "Confirm your email"
+
+#: forms.py:66
 msgid "Confirmez votre adresse."
 msgstr "Confirm you email."
 
 #: forms.py:69
-msgid "Vous pourrez modifier cela plus tard"
-msgstr "You can modify this later"
-
-#: forms.py:75
-msgid "Adresse mail"
-msgstr "Email"
-
-#: forms.py:76
-msgid "Confirmation de l'adresse mail"
-msgstr "Confirm your email"
-
-#: forms.py:77
-msgid "Prénom"
-msgstr "First name"
-
-#: forms.py:78
-msgid "NOM"
-msgstr "Last name"
-
-#: forms.py:79 forms.py:136
-msgid "Mot de passe"
-msgstr "Password"
-
-#: forms.py:80
-msgid "Confirmation du mot de passe"
-msgstr "Confirm your password"
-
-#: forms.py:82
-msgid "Entrez le même mot de passe pour vérification"
-msgstr "Enter the same password for verification"
-
-#: forms.py:84
 msgid "Année d'arrivée à Centrale"
 msgstr "Year of arrival at Centrale Nantes"
 
-#: forms.py:85
+#: forms.py:74
+msgid "Prénom"
+msgstr "First name"
+
+#: forms.py:77
+msgid "Nom"
+msgstr "Last name"
+
+#: forms.py:80
 msgid "Filière"
 msgstr "Formation followed"
 
-#: forms.py:86
+#: forms.py:83
 msgid "Cursus particulier ?"
 msgstr "Are you in a special programm?"
 
+#: forms.py:85
+msgid "Vous pourrez modifier cela plus tard"
+msgstr "You can modify this later"
+
+#: forms.py:91 forms.py:137
+msgid "Mot de passe"
+msgstr "Password"
+
+#: forms.py:92
+msgid "Confirmation du mot de passe"
+msgstr "Confirm your password"
+
 #: forms.py:94
+msgid "Entrez le même mot de passe pour vérification"
+msgstr "Enter the same password for verification"
+
+#: forms.py:103
 msgid "Cet email est déjà utilisé."
 msgstr "This email is already being used."
 
-#: forms.py:99
+#: forms.py:108
 msgid "Les emails ne correspondent pas."
 msgstr "The emails don't match."
 
-#: forms.py:151
+#: forms.py:152
 msgid "Entrez l'adresse mail associée au compte"
 msgstr "Enter the email associated with your account"
 
-#: forms.py:165
+#: forms.py:166
 msgid "Votre nouveau mot de passe"
 msgstr "Your new password"
 
-#: forms.py:166
+#: forms.py:167
 msgid "Confirmer le mot de passe"
 msgstr "Confirm your password"
 
-#: forms.py:189
+#: forms.py:190
 msgid "Votre adresse mail personnelle."
 msgstr "Your personal email."
 
-#: forms.py:202
+#: forms.py:203
 msgid "Votre adresse mail Centrale Nantes."
 msgstr "Your Centrale Nantes email."
 
 #: templates/account/confirm-email.html:11
-#, fuzzy
-#| msgid "Confirmez votre adresse."
 msgid "Confirmez votre adresse email"
 msgstr "Confirm your email address"
 

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -17,6 +17,10 @@ class User(AbstractUser):
 
     email = models.EmailField(unique=True)
 
+    def save(self, *args, **kwargs):
+        self.email = self.email.lower()
+        super().save(*args, **kwargs)
+
 
 class IdRegistration(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=True)

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -48,4 +48,4 @@ class TemporaryAccessRequest(models.Model):
             if domain is not None:
                 self.domain = domain
             self.approved_until = settings.TEMPORARY_ACCOUNTS_DATE_LIMIT
-            super(TemporaryAccessRequest, self).save()
+            super().save()

--- a/backend/apps/account/utils.py
+++ b/backend/apps/account/utils.py
@@ -23,7 +23,7 @@ def user_creation(
     # save with username = email by default
     user: User = form.instance
     user.username = user.email
-    user.save()
+    form.save()
 
     user.student.promo = form.cleaned_data.get("promo")
     user.student.faculty = form.cleaned_data.get("faculty")

--- a/backend/apps/account/views.py
+++ b/backend/apps/account/views.py
@@ -141,8 +141,8 @@ class AuthView(FormView):
             )
             messages.warning(request, message)
             return redirect(url)
-        else:
-            return super(AuthView, AuthView).get(self, request)
+
+        return super().get(self, request)
 
     def form_invalid(self, form):
         message = "Veuillez vous connecter avec votre adresse mail ECN."


### PR DESCRIPTION
# Description

Solve issue #1139 

When upgrading to a definitive account with a ECN email address, we must transform the email into lowercase before saving it.