### PR TITLE
Feat/support-codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/pipenv:2": {}
+  },
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "5173": { "onAutoForward": "silent" }
+  },
+  "postCreateCommand": "make install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // global
+        "eamodio.gitlens",
+        "visualstudioexptteam.vscodeintellicode",
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-french",
+        "mikestead.dotenv",
+        "simonsiefke.svg-preview",
+        // python
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.flake8",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "njpwerner.autodocstring",
+        // django
+        "batisteo.vscode-django",
+        "mrorz.language-gettext",
+        "qwtel.sqlite-viewer",
+        "ecmel.vscode-html-css",
+        // js
+        "dbaeumer.vscode-eslint",
+        "christian-kohler.npm-intellisense",
+        "cschlosser.doxdocgen",
+        "esbenp.prettier-vscode",
+        // react
+        "lokalise.i18n-ally",
+        // docs
+        "unifiedjs.vscode-mdx",
+        "pomdtr.excalidraw-editor"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,10 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/pipenv:2": {}
   },
-  "forwardPorts": [8000],
+  "forwardPorts": [8000, 5173],
   "portsAttributes": {
-    "5173": { "onAutoForward": "silent" }
+    "5173": { "onAutoForward": "silent" },
+    "8000": { "onAutoForward": "openBrowserOnce" }
   },
   "postCreateCommand": "make install",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
     "5173": { "onAutoForward": "silent" },
     "8000": { "onAutoForward": "openBrowserOnce" }
   },
-  "postCreateCommand": "make install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "simonsiefke.svg-preview",
     // python
     "ms-python.python",
+    "ms-python.vscode-pylance",
     "ms-python.flake8",
     "ms-python.black-formatter",
     "ms-python.isort",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,8 @@
   "[django-html]": {
     "editor.formatOnSave": false
   },
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.typeCheckingMode": "off",
   "flake8.args": ["--config", "backend/.flake8"],
   "flake8.importStrategy": "fromEnvironment",
   "black-formatter.args": ["--config", "backend/pyproject.toml"],

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ install:
 	cd email-templates-generator && \
 		npm ci && \
 		npm run build
+	cd docs && \
+		npm ci
 
 
 # Update after pull

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -46,7 +46,7 @@ requests = "~=2.28"
 six = "~=1.16"
 # force update of a sub-package
 pyjwt = ">=2.4"
-django-rest-passwordreset = "*"
+django-rest-passwordreset = "~=1.4"
 factory-boy = "~=3.3.0"
 
 [dev-packages]

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b77f1d36d7de93987d38a278b2cdc41be103ca110eabbfd3a17ce80ca8ba7e35"
+            "sha256": "922e7d983c91ba960d105c18ac1cad62db68afd2f49320241cd84160674412de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.8.1"
         },
+        "async-timeout": {
+            "hashes": [
+                "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f",
+                "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"
+            ],
+            "markers": "python_full_version < '3.11.3'",
+            "version": "==4.0.3"
+        },
         "billiard": {
             "hashes": [
                 "sha256:07aa978b308f334ff8282bd4a746e681b3513db5c9a514cbdd810cbbdc19714d",
@@ -49,18 +57,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:139dd2d94eaa0e3213ff37ba7cf4cb2e3823269178fe8f3e33c965f680a9ddde",
-                "sha256:265b0b4865e8c07e27abb32a31d2bd9129bb009b1d89ca0783776ec084886123"
+                "sha256:5627f6ecadb46fc7c9f8c368baf948f1b00a3fd2f8eb1275c254469853ad8fdb",
+                "sha256:bb8f433c04dcdffbd4a802df56c1c30f2be23b1161fd8fb45e4b76c1487ec122"
             ],
-            "version": "==1.34.79"
+            "version": "==1.34.80"
         },
         "botocore": {
             "hashes": [
-                "sha256:6b59b0f7de219d383a2a633f6718c2600642ebcb707749dc6c67a6a436474b7a",
-                "sha256:a42a014d3dbaa9ef123810592af69f9e55b456c5be3ac9efc037325685519e83"
+                "sha256:354a00f03faba52acc6f1a84fa4f035d48541633be98ccc24b59dc544f679f8b",
+                "sha256:8402262e819f3d46df504bbd781e770858c0130b90f660699f75ef3a63abca5a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.79"
+            "version": "==1.34.80"
         },
         "celery": {
             "hashes": [
@@ -860,7 +868,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -910,7 +918,7 @@
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sqlparse": {
@@ -1464,8 +1472,16 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "typing-extensions": {
             "hashes": [

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -44,6 +44,10 @@ env = environ.Env(
     OVH_ACCESS_KEY_ID=(str, ""),
     OVH_SECRET_ACCESS_KEY=(str, ""),
     S3_BUCKET=(str, ""),
+    # for codespaces only (automatically retrieved from the codespace)
+    CODESPACES=(bool, False),
+    CODESPACE_NAME=(str, ""),
+    GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN=(str, ""),
 )
 env.read_env()
 
@@ -168,8 +172,13 @@ MODELTRANSLATION_CUSTOM_FIELDS = ("CKEditor5Field",)
 # Compile frontend with VITE
 DJANGO_VITE_ASSETS_PATH = os.path.join(BASE_DIR, "static/front")
 DJANGO_VITE_DEV_MODE = True
-DJANGO_VITE_DEV_SERVER_PORT = 5173
 
+if env("CODESPACES"):
+    CODESPACE_NAME = env("CODESPACE_NAME")
+    CODESPACE_DOMAIN = env("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+    DJANGO_VITE_DEV_SERVER_PROTOCOL = "https"
+    DJANGO_VITE_DEV_SERVER_HOST = f"{CODESPACE_NAME}-5173.{CODESPACE_DOMAIN}"
+    DJANGO_VITE_DEV_SERVER_PORT = 443
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/

--- a/docs/docs/dev/get-started/install-party/index.md
+++ b/docs/docs/dev/get-started/install-party/index.md
@@ -3,8 +3,8 @@ title: Install Party
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
 
 # Install Party
 
@@ -91,8 +91,13 @@ Remember it, they are very useful! 🤩
 
 </details>
 
+:::tip Don't have time?
+You can skip the installation by working directly in your browser.
+See the **_Pick an OS_** section.  
+:::
+
 ---
 
-import DocCardList from '@theme/DocCardList';
+import DocCardList from '@theme/DocCardList'
 
 <DocCardList />

--- a/docs/docs/dev/get-started/install-party/pick-an-os.md
+++ b/docs/docs/dev/get-started/install-party/pick-an-os.md
@@ -9,41 +9,26 @@ their pros and cons.
 
 ## Summary
 
-| My situation                                           | The choice we recommend                                |
-| ------------------------------------------------------ | ------------------------------------------------------ |
-| I have a Mac                                           | Use MacOS                                              |
-| I already know Linux or I am interested in learning it | Use Linux                                              |
-| I have a Windows with good performances                | Use WSL                                                |
-| I have a Windows with very bad performances            | Use Windows (or Linux if you want better performances) |
+| My situation                                           | The choice we recommend |
+| ------------------------------------------------------ | ----------------------- |
+| I have a Mac                                           | Use MacOS               |
+| I already know Linux or I am interested in learning it | Use Linux               |
+| I have a Windows with good performances                | Use WSL                 |
+| I have a Windows with very bad performances            | Use Github Codespaces   |
 
 ## Pros and cons of each OS
-
-### Windows
-
-✅ Pros: you already know how to use it and are familiar with the interface.
-
-❌ Cons: you will have more bugs and problems during development, because
-Windows is not meant for web development (it is not a Unix-based system).
-
-### MacOS
-
-✅ Pros: easy to use and perfect for web development, since it is a Unix-based
-system.
-
-❌ Cons: it is expensive and you need to buy a Mac. You will also have less
-compatibility with other devices.
 
 ### Linux
 
 ✅ Pros: it is perfect for web development, as a Unix-based system.
 It is also free, installable on any computer, you can dual-boot it with Windows,
-and has a lot more tools for devs than Windows or MacOS.
+and it has a lot more tools for devs than Windows or MacOS.
 
 ❌ Cons: you will need to learn how to use it, and it is not as user-friendly
 as Windows or MacOS.
 
 <details>
-<summary>Instructions for Linux...</summary>
+<summary>How to install Linux</summary>
 
 You'll need to pick a distribution to start with. If you are a beginner,
 we recommend you to use an _Ubuntu_-based distribution: they have great
@@ -58,28 +43,71 @@ Some of the best _Ubuntu_-based distributions:
 
 </details>
 
+### MacOS
+
+✅ Pros: very easy to use, and perfect for web development (it is also based on Unix,
+as for Linux).
+
+❌ Cons: it is expensive and you need to buy a Mac. Apple is also known
+for spying its users.
+
+### Windows
+
+✅ Pros: you probably already know how to use it and are familiar with the
+interface.
+
+❌ Cons: you will have more bugs and problems during development, because
+Windows is not meant for web development (it is not a Unix-based system).
+
 ### WSL (Windows Subsystem for Linux)
 
-If you are hesitating between Windows and Linux, you can use the best of both
-with WSL: basically, it is a Linux system which runs inside your Windows.
+If you are hesitating about installing Linux, you can use the best of Windows
+and Linux with WSL: basically, it is a full Linux system which runs inside your
+Windows.
 
 ✅ Pros: you keep the Windows interface that you're familiar with, but you can
 also use all the Linux tools for web development.
 
-❌ Cons: your computer will consume more power and RAM to run both Windows
+❌ Cons: your computer will need more power and RAM to run both Windows
 and Linux at the same time.
 
 <details>
-<summary>Instructions for WSL...</summary>
+<summary>How to install WSL</summary>
 
-First, you need to install **WSL2** on your Windows. Follow the official instructions
-of the Microsoft documentation to do this, because it can be a bit tricky.
+First, you need to install **WSL2** on your Windows. Be sure to follow
+[the official Microsoft documentation](https://learn.microsoft.com/en-us/windows/wsl/install),
+because it can be a bit tricky.
 
 Then, you need to pick a distribution to start with: we recommend you to use
 _Ubuntu_.
 
 Finally, you need to install all programs and tools for your Linux system:
 to do so, follow this documentation using the _Linux_ tab each time instead of
-the _Windows_ tab.
+the _Windows_ tab, and run commands in the WSL terminal.
+
+</details>
+
+### Github Codespaces
+
+Codespaces allows you to use a remote Linux machine, which runs on the Github
+servers.
+
+✅ Pros: you don't need to install anything (the remote machine is already
+configured with all tools), and you can access it from anywhere through a
+browser. It is also perfect if your computer does not have good performances.
+
+❌ Cons: codespaces can be automatically deleted by Github after a certain
+period of time if they are not used, so you need to be sure to commit and push
+your changes frequently.
+
+<details>
+<summary>How to use Github Codespaces</summary>
+
+1. Open the [Github repository](https://github.com/3cn-ecn/nantralPlatform)
+   page.
+2. Click the **Code** button, select **Codespaces**, and create a new
+   codespace.
+3. Wait for the codespace to be created. After it is done, you can directly
+   go to the [First launch](../setup-project/setup-project.md) page.
 
 </details>

--- a/docs/docs/dev/get-started/setup-project/setup-project.md
+++ b/docs/docs/dev/get-started/setup-project/setup-project.md
@@ -2,8 +2,8 @@
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
 
 # First Launch
 
@@ -101,6 +101,10 @@ Congratulations, you did it all 🥳
 
 </details>
 
+When the installation is finished, refresh your IDE: for VScode, tap
+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>, search for **"Reload Windows"**,
+and tap <kbd>Enter</kbd>.
+
 ## Start the server
 
 Now it's time to launch the website! To do this:
@@ -115,7 +119,33 @@ Now it's time to launch the website! To do this:
    cd backend/
    pipenv run start
    ```
-1. Open this address in your browser: [http://localhost:8000](http://localhost:8000)
+
+<Tabs>
+<TabItem value="local" label="Local">
+
+3. Open this address in your browser: [http://localhost:8000](http://localhost:8000)
+
+</TabItem>
+<TabItem value="codespaces" label="Github Codespaces">
+
+3. The ports 8000 and 5173 are automatically **forwarded** by VScode. The port
+   8000 is automatically opened in **a new tab**.
+4. Go back into the vscode tab of your browser. You need to change
+   the **visibility** of the ports to **public**:
+
+   - open the **_Ports_** tab on the bottom bar of VS code
+   - right click on each port, and select _Port visibility_ > _Public_
+
+   You can also run this command to change the visibility of both ports:
+
+   ```
+   gh codespace ports visibility 5173:public 8000:public --codespace $CODESPACE_NAME
+   ```
+
+5. Go back to the tab **previously** opened automatically.
+
+</TabItem>
+</Tabs>
 
 And that's it! You should now see the login page of Nantral Platform:
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,8 +35,8 @@ export default defineConfig({
   base: '/static/',
   resolve: {
     alias: {
-      '#api': path.resolve(__dirname, './src/api/'),
-      '#modules': path.resolve(__dirname, './src/modules/'),
+      '#api': path.resolve(__dirname, './src/api'),
+      '#modules': path.resolve(__dirname, './src/modules'),
       '#pages': path.resolve(__dirname, './src/pages'),
       '#shared': path.resolve(__dirname, './src/shared'),
       '#types': path.resolve(__dirname, './src/types'),


### PR DESCRIPTION
# Description

Add support to develop on NP in a github codespace.

# How it works

1. Create a new codespace (with the "Code" button from Github)
2. Everything is installed automatically
3. Run `make install`
4. Start the front end : `cd frontend && npm run start`
5. Start the back end : `cd backend && pipenv run start`
6. Make forwarded ports public: `gh codespace ports visibility 5173:public 8000:public --codespace $CODESPACE_NAME`

