### PR TITLE
fix(1291): timezone issue

### DIFF
--- a/deployment/stack/postgres.yml
+++ b/deployment/stack/postgres.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:14.1
     expose:
       - "5432"
-    environment:
-      - "TZ=Europe/Paris"
+    # environment:
+      # - "TZ=Europe/Paris"
     volumes:
-      - "/etc/timezone:/etc/timezone:ro"
-      - "/etc/localtime:/etc/localtime:ro"
+      # - "/etc/timezone:/etc/timezone:ro"
+      # - "/etc/localtime:/etc/localtime:ro"
       - postgres_data:/var/lib/postgresql/data/
     env_file: ../backend.env
     networks:


### PR DESCRIPTION
# Description

Fix the timezone issue.

I'm not 100% sure why it's happening. My guess is that we spawned the database in UTC. Then, in https://github.com/3cn-ecn/nantralPlatform/pull/1281/files#diff-2b55e4c5b746598b1dd89b62c657486786aaf3faca0d6c95c7225f619d47e164 we (me) modified the compose file to make the database timezone aware. It seems like it messed up the timestamps.

We can keep the database timezone unaware for now.

# Investigation (the following are before the fix)

Event 496 was scheduled between 21h and 22h CEST, directly from the UI.

```
nantral_staging=# select start_date, title, id from event_event where id = 496;
       start_date       |       title       | id  
------------------------+-------------------+-----
 2025-04-02 21:00:00+02 | Test des familles | 496
(1 row)
```

```

nantral_staging=# SELECT start_date, timezone('UTC', start_date), timezone('Europe/Paris', start_date) FROM event_event WHERE id = 496;
       start_date       |      timezone       |      timezone       
------------------------+---------------------+---------------------
 2025-04-02 21:00:00+02 | 2025-04-02 19:00:00 | 2025-04-02 21:00:00
(1 row)
```

I don't have the data anymore but doing the following from the shell resulted in an incorrect result:

```
>>> Event.objects.get(id=496).start_date
datetime(...., timezone=utc) # wrong
```

For some reason, the UI was cool with it, i.e everything worked as expected.
