### PR TITLE
feat: Add a button in login page to resend an email if it is not valid

### DIFF
--- a/frontend/src/pages/Login/Login.page.tsx
+++ b/frontend/src/pages/Login/Login.page.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { Check } from '@mui/icons-material';
 import {
   Alert,
   Button,
@@ -9,7 +10,9 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
 
+import { resendVerificationEmailApi } from '#modules/account/api/email.api';
 import { LoginFormFields } from '#modules/account/view/shared/LoginFormFields';
 import { FlexRow } from '#shared/components/FlexBox/FlexBox';
 import { FloatingContainer } from '#shared/components/FloatingContainer/FloatingContainer';
@@ -29,6 +32,12 @@ export default function LoginPage() {
     email: string;
     password: string;
   }>({ email: '', password: '' });
+
+  const {
+    isSuccess: isResendSuccess,
+    mutate,
+    isLoading: isResendLoading,
+  } = useMutation(resendVerificationEmailApi);
 
   const { login, error, isLoading } = useAuth();
 
@@ -83,7 +92,30 @@ export default function LoginPage() {
           }}
         >
           {error?.response?.data?.message && (
-            <Alert severity="error">{error?.response?.data?.message}</Alert>
+            <Alert
+              severity="error"
+              action={
+                error?.response?.data?.code == '1' /* Email not valid */ &&
+                (isResendSuccess ? (
+                  <Check color="success" />
+                ) : (
+                  <LoadingButton
+                    loading={isResendLoading}
+                    variant="outlined"
+                    color="inherit"
+                    size="small"
+                    sx={{ textTransform: 'none' }}
+                    onClick={() => {
+                      mutate(formValues.email);
+                    }}
+                  >
+                    {t('register.sendAgain')}
+                  </LoadingButton>
+                ))
+              }
+            >
+              {error?.response?.data?.message}
+            </Alert>
           )}
           <LoginFormFields
             formValues={formValues}


### PR DESCRIPTION
# Description

Ajout d'un bouton pour renvoyer l'email de vérification dans le message d'erreur de la page de connexion.
Le but est de permettre aux utilisateurs qui n'ont pas reçu le mail de connexion et qui ont fermé la page de pouvoir se connecter à nouveau.

# Screenshots

![image](https://github.com/user-attachments/assets/e0fe64c8-8c8f-4543-bd7a-8198a5d53fd4)

![image](https://github.com/user-attachments/assets/b4e1d966-2eac-4155-aad9-da4aba149a62)


