### PR TITLE
Fix 500 error in the housing map/list

### DIFF
--- a/backend/apps/utils/slug.py
+++ b/backend/apps/utils/slug.py
@@ -65,6 +65,11 @@ class SlugModel:
                 while model.objects.filter(slug=f"{slug}-{num}").exists():
                     num += 1
                 slug = f"{slug}-{num}"
+            if not slug:
+                num = 1
+                while model.objects.filter(slug=str(num)).exists():
+                    num += 1
+                slug = str(num)
             self.slug = slug
 
 


### PR DESCRIPTION
See #1330

# Description

Empty slugs caused an error when trying to view the housing map and list.

The fix is to assign a number as a slug when a group has an empty slugs.

