### PR TITLE
Fix: Création d'un super-utilisateur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ install:
 	cd backend/config/settings && \
 		$(COPY) .env.example .env
 	cd backend && \
-		mkdir "static/front" && \
+		mkdir "static/front" -p && \
 		$(call EXPORT,PIPENV_VENV_IN_PROJECT,1) && \
 		$(PIPENV) sync --dev && \
 		$(PIPENV) run migrate && \
 		$(call EXPORT,DJANGO_SUPERUSER_PASSWORD,admin) && \
-		$(PIPENV) run django createsuperuser --noinput --username admin --username admin --email admin@ec-nantes.fr && \
+		$(PIPENV) run django createsuperuser --noinput --username admin --email admin@ec-nantes.fr && \
 		$(PIPENV) run fakedata
 	cd frontend && \
 		npm ci

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -114,7 +114,13 @@ class User(AbstractUser):
         ordering = ["last_name", "first_name", "username"]
 
     def __str__(self):
-        return f"{self.student.alphabetical_name if hasattr(self, "student") else str(self.email)} ({self.username})"
+        if hasattr(self, "student"):
+            name = self.student.alphabetical_name
+        elif hasattr(self, "email"):
+            name = str(self.email)
+        else:
+            return self.username
+        return f"{name} ({self.username})"
 
 
 class Email(models.Model):

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -37,7 +37,7 @@ class InvitationLink(models.Model):
 
 
 class User(AbstractUser):
-    USERNAME_FIELD = "email_id"
+    USERNAME_FIELD = "email"
     EMAIL_FIELD = "email__email"
     REQUIRED_FIELDS = ["username"]
 
@@ -55,7 +55,7 @@ class User(AbstractUser):
             "unique": _("This username is already taken."),
         },
     )
-    email = models.OneToOneField("Email", verbose_name=_("Main email"), on_delete=models.RESTRICT, related_name="primary_from", null=True)
+    email = models.OneToOneField("Email", verbose_name=_("Main email"), on_delete=models.RESTRICT, related_name="primary_from")
     invitation = models.ForeignKey(
         InvitationLink,
         null=True,

--- a/backend/apps/core/management/commands/createsuperuser.py
+++ b/backend/apps/core/management/commands/createsuperuser.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.management.commands import createsuperuser
+from django.utils.text import capfirst
+
+
+class Command(createsuperuser.Command):
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+
+    def _validate_username(self, username, verbose_field_name, database):
+        """Validate username. If invalid, return a string error message."""
+
+        if self.username_is_unique:
+            try:
+                self.UserModel._default_manager.db_manager(database).get_by_natural_key(
+                    username
+                )
+            except self.UserModel.DoesNotExist:
+                pass
+            else:
+                return f"Error: That {verbose_field_name} is already taken."
+        if not username:
+            return f"{capfirst(verbose_field_name)} cannot be blank."

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -108,7 +108,7 @@ ARCHIVED_APPS = [
     "apps._archived.administration",
     "apps._archived.academic",
 ]
-INSTALLED_APPS = DJANGO_APPS + COMMON_APPS + THIRD_PARTY_APPS + ARCHIVED_APPS
+INSTALLED_APPS = COMMON_APPS + DJANGO_APPS + THIRD_PARTY_APPS + ARCHIVED_APPS
 
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",


### PR DESCRIPTION
Erreur lors de la création d'un super-utilisateur (avec la commande make par exemple)

Problème dû à la vérification de l'email en tant qu'objet `Email`, alors que l'email est censé être une chaîne de caractères.