### PR TITLE
Fix CKEditor text color in dark theme

### DIFF
--- a/frontend/src/shared/ckeditor/custom.styles.scss
+++ b/frontend/src/shared/ckeditor/custom.styles.scss
@@ -1,5 +1,7 @@
 :root {
   --np-red: #dc3545;
+  --ck-color-base-text: inherit;
+  --ck-color-text: inherit;
   --ck-color-link-default: var(--np-red);
   --ck-color-base-active: var(--np-red);
   --ck-color-button-on-color: var(--np-red);
@@ -17,6 +19,11 @@
 
   .ck-content {
     overflow-x: auto;
+    color: inherit;
+
+    * {
+      color: inherit;
+    }
 
     a {
       color: var(--ck-color-link-default);

--- a/frontend/src/shared/components/RichTextRenderer/RichTextRenderer.tsx
+++ b/frontend/src/shared/components/RichTextRenderer/RichTextRenderer.tsx
@@ -7,7 +7,7 @@ interface RichTextRendererProps {
   content: string;
 }
 
-export function RichTextRenderer({ content }: RichTextRendererProps) {
+export function RichTextRenderer({ content }: Readonly<RichTextRendererProps>) {
   return (
     <Typography
       // default classes included in the CKEditor component

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -21,9 +21,11 @@ function getTheme(mode: PaletteMode, language: string) {
         },
         secondary: {
           main: mode === 'light' ? '#536873' : '#99AEB8',
+          contrastText: mode === 'light' ? '#FFFFFF' : '#000000',
         },
         neutral: {
           main: '#efefef',
+          contrastText: mode === 'light' ? '#000000' : '#FFFFFF',
         },
         warning: {
           main: '#ffc107',


### PR DESCRIPTION
# Description

Changement de la couleur du texte de CKEditor de manière à hériter du thème de MaterialUI et mieux supporter le thème sombre

