### PR TITLE
fix: 500 error in the `ConfirmUser` view due to a call to function that does not exist anymore

### DIFF
--- a/backend/apps/account/serializers.py
+++ b/backend/apps/account/serializers.py
@@ -14,7 +14,7 @@ from apps.sociallink.serializers import SocialLinkSerializer
 from .models import FACULTIES, PATHS, Email, InvitationLink, User
 from .validators import (
     django_validate_password,
-    ecn_email_validator,
+    organisation_email_validator,
     validate_email,
     validate_matrix_username,
 )
@@ -30,7 +30,7 @@ class LoginSerializer(serializers.Serializer):
         max_length=200,
         validators=[
             validate_email,
-            ecn_email_validator,
+            organisation_email_validator,
             UniqueValidator(
                 Email.objects.all().annotate(email_ecn=F("email")),
                 message=_(
@@ -50,7 +50,7 @@ class RegisterSerializer(serializers.Serializer):
         max_length=200,
         validators=[
             validate_email,
-            ecn_email_validator,
+            organisation_email_validator,
             UniqueValidator(
                 Email.objects.all(),
                 message=_(

--- a/backend/apps/account/validators.py
+++ b/backend/apps/account/validators.py
@@ -126,17 +126,3 @@ def get_user_organization(emails):
         return None
     valid_orgs.sort(key=lambda org: org.account_organization_priority)
     return valid_orgs[0].organization
-
-
-def ecn_email_validator(mail: str):
-    if (
-        re.search(
-            r"@([\w\-.]+\.)?(ec-nantes\.fr|centraliens-nantes\.org)$", mail
-        )
-        is None
-    ):
-        raise ValidationError(
-            _(
-                "You must use a valid ECN email address (ending in ec-nantes.fr or centraliens-nantes.org)"
-            ),
-        )

--- a/backend/apps/account/views.py
+++ b/backend/apps/account/views.py
@@ -28,7 +28,7 @@ class ConfirmUser(View):
             email.save()
 
             user.is_active = True
-            if email.is_ecn_email():
+            if email.is_authorized_organisation_email():
                 user.invitation = None
             user.save()
 


### PR DESCRIPTION
This commit also fixes the validator used in the account serializers to use the new version and remove the old `ecn_email_validator`