### PR TITLE
Separate backend and staging env files

### DIFF
--- a/deployment/stack/backend.yml
+++ b/deployment/stack/backend.yml
@@ -40,7 +40,7 @@ services:
     depends_on:
       - database
       - redis
-    env_file: ../backend.env
+    env_file: ../backend-staging.env
     environment:
       - STAGING=True
       - "TZ=Europe/Paris"


### PR DESCRIPTION
This allows to use different environment variables for the staging

A new `backend-staging.env` file will be created with values specific to the staging server
