### PR TITLE
fix: correctly check if arrays are nan in family algorithm

### DIFF
--- a/backend/apps/family/admin_views.py
+++ b/backend/apps/family/admin_views.py
@@ -1,5 +1,6 @@
 # ruff: noqa: N806
 import sys
+import traceback
 
 from django.contrib import messages
 from django.db.models import Q
@@ -128,12 +129,10 @@ class ResultsView(UserIsInGroup, TemplateView):
                         },
                     )
         except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
+            exc = sys.exc_info()
             message = format_html(
-                "An error occurred while creating the families: {}: {}<br/><pre><code>{}</code></pre>",
-                exc_type,
-                exc_value,
-                exc_traceback,
+                "An error occurred while creating the families:<br/><pre><code>{}</code></pre>",
+                "\n".join(traceback.format_exception(*exc)),
             )
             messages.error(self.request, message)
         context["families"] = families

--- a/backend/apps/family/algorithm/utils.py
+++ b/backend/apps/family/algorithm/utils.py
@@ -221,7 +221,7 @@ def get_family_list(member2A_list):
             [m["answers"] for m in member2A_list if m["family"] == fam],
         )
         answers_mean = np.nanmean(answers_list, axis=0)
-        if np.isnan(answers_mean):
+        if answers_mean is np.nan:  # noqa: PLW0177
             raise Exception(f"Family {fam.name} has no members")
         if vectisnan(answers_mean):
             raise Exception(f"Members of {fam.name} have no answers")
@@ -230,7 +230,7 @@ def get_family_list(member2A_list):
             [m["coeff"] for m in member2A_list if m["family"] == fam],
         )
         coeff_mean = np.nanmean(coeff_list, axis=0)
-        if np.isnan(coeff_mean):
+        if coeff_mean is np.nan:  # noqa: PLW0177
             raise Exception(f"Family {fam.name} has no members")
         if vectisnan(coeff_mean):
             raise Exception(f"Members of {fam.name} have no answers")


### PR DESCRIPTION
Was altered in #1408 in an attempt to fix ruff issues, but the fix was changing the behavior of the app.

This commit also fix the error display in parrainage admin page